### PR TITLE
Add support for building under gcc 11.2.1 on Linux

### DIFF
--- a/examples/dump-decls/Presenter.cpp
+++ b/examples/dump-decls/Presenter.cpp
@@ -17,8 +17,10 @@ void Presenter::present(ifc::NameIndex name) const
         out_ << file_.get_string(ifc::TextOffset{name.index});
         break;
     case Operator:
-        const auto operator_function_name = file_.operator_names()[name];
-        out_ << "operator" << file_.get_string(operator_function_name.encoded);
+        {
+            const auto operator_function_name = file_.operator_names()[name];
+            out_ << "operator" << file_.get_string(operator_function_name.encoded);
+        }
         break;
     default:
         out_ << "Unsupported NameSort '" << static_cast<int>(kind) << "'";

--- a/lib/core/include/ifc/AbstractReference.h
+++ b/lib/core/include/ifc/AbstractReference.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <type_traits>
+#include <cstdint>
 
 namespace ifc
 {

--- a/lib/core/include/ifc/common_types.h
+++ b/lib/core/include/ifc/common_types.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstddef>
 
 namespace ifc
 {


### PR DESCRIPTION
This PR fixes some (very simple) build-time issues I had when compiling with gcc 11.2.1 on openSUSE.

It does not currently build with clang-12.

Signed-off-by: Andrew V. Jones <andrewvaughanj@gmail.com>