### PR TITLE
Fixes for gcc related to not using a forward-declared type with optional

### DIFF
--- a/lib/core/include/ifc/Declaration.h
+++ b/lib/core/include/ifc/Declaration.h
@@ -8,6 +8,7 @@
 #include "NoexceptSpecification.h"
 #include "Scope.h"
 #include "SourceLocation.h"
+#include "Type.h"
 
 #include <string_view>
 

--- a/lib/core/include/ifc/Expression.h
+++ b/lib/core/include/ifc/Expression.h
@@ -6,6 +6,8 @@
 
 #include "common_types.h"
 
+#include "Type.h"
+
 #include <string_view>
 
 namespace ifc

--- a/lib/core/include/ifc/File.h
+++ b/lib/core/include/ifc/File.h
@@ -3,11 +3,11 @@
 #include "FileHeader.h"
 #include "Partition.h"
 
-#include "ChartFwd.h"
-#include "ExpressionFwd.h"
-#include "DeclarationFwd.h"
-#include "NameFwd.h"
-#include "TypeFwd.h"
+#include "Chart.h"
+#include "Expression.h"
+#include "Declaration.h"
+#include "Name.h"
+#include "Type.h"
 
 #include <boost/iostreams/device/mapped_file.hpp>
 

--- a/lib/core/include/ifc/Type.h
+++ b/lib/core/include/ifc/Type.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "TypeFwd.h"
+#include "DeclarationFwd.h"
+#include "NoexceptSpecification.h"
 
 #include "CallingConvention.h"
 


### PR DESCRIPTION
In https://github.com/AndreyG/ifc-reader/commit/51176473e636db2c270471b36bdeea071ffc525b caches were added using `optional`:

- https://github.com/AndreyG/ifc-reader/blob/51176473e636db2c270471b36bdeea071ffc525b/lib/core/include/ifc/File.h#L34

However, under `gcc`, you need to have the complete type (not just the forward decl) to use it with `optional`.

This PR corrects things such they now build under Linux.

Signed-off-by: Andrew V. Jones <andrewvaughanj@gmail.com>