### PR TITLE
Create an optional 'path_to_metadata' argument in the environment class

### DIFF
--- a/examples/dump-decls/main.cpp
+++ b/examples/dump-decls/main.cpp
@@ -11,7 +11,7 @@ int main(int argc, char* argv[])
 {
     if (argc < 2 || argc > 3)
     {
-        std::cerr << "expected: <path to .ifc file> <optional path to source dep json>\n";
+        std::cerr << "expected: <path to .ifc file> <(optional) path to metadata>\n";
         return EXIT_FAILURE;
     }
 

--- a/lib/core/include/ifc/Declaration.h
+++ b/lib/core/include/ifc/Declaration.h
@@ -8,6 +8,7 @@
 #include "NoexceptSpecification.h"
 #include "Scope.h"
 #include "SourceLocation.h"
+#include "Type.h"
 
 #include <string_view>
 

--- a/lib/core/include/ifc/Environment.h
+++ b/lib/core/include/ifc/Environment.h
@@ -4,13 +4,14 @@
 
 #include <unordered_map>
 #include <vector>
+#include <optional>
 
 namespace ifc
 {
     class Environment
     {
     public:
-        File const & get_module_by_bmi_path (std::string const &);
+        File const & get_module_by_bmi_path (std::string const &, std::optional<std::string> const&);
         File const & get_module_by_name     (std::string const &);
 
     protected:
@@ -34,7 +35,7 @@ namespace ifc
             std::vector<Module> imported_modules;
         };
 
-        virtual Config get_config(std::string const & path_to_bmi) const = 0;
+        virtual Config get_config(std::string const & path_to_bmi, std::optional<std::string> const&) const = 0;
 
     private:
         void fill_name_to_path_mapping(Config);

--- a/lib/core/include/ifc/Expression.h
+++ b/lib/core/include/ifc/Expression.h
@@ -6,6 +6,8 @@
 
 #include "common_types.h"
 
+#include "Type.h"
+
 #include <string_view>
 
 namespace ifc

--- a/lib/core/include/ifc/File.h
+++ b/lib/core/include/ifc/File.h
@@ -3,11 +3,11 @@
 #include "FileHeader.h"
 #include "Partition.h"
 
-#include "ChartFwd.h"
-#include "ExpressionFwd.h"
-#include "DeclarationFwd.h"
-#include "NameFwd.h"
-#include "TypeFwd.h"
+#include "Chart.h"
+#include "Expression.h"
+#include "Declaration.h"
+#include "Name.h"
+#include "Type.h"
 
 #include <boost/iostreams/device/mapped_file.hpp>
 

--- a/lib/core/include/ifc/Type.h
+++ b/lib/core/include/ifc/Type.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "TypeFwd.h"
+#include "DeclarationFwd.h"
+#include "NoexceptSpecification.h"
 
 #include "CallingConvention.h"
 

--- a/lib/core/src/Environment.cpp
+++ b/lib/core/src/Environment.cpp
@@ -1,13 +1,15 @@
 #include "ifc/Environment.h"
 
+#include <optional>
+
 namespace ifc
 {
-    File const& Environment::get_module_by_bmi_path(std::string const & key)
+    File const& Environment::get_module_by_bmi_path(std::string const & key, std::optional<std::string> const& path_to_metadata)
     {
         auto cached = cached_bmis_.find(key);
         if (cached == cached_bmis_.end())
         {
-            fill_name_to_path_mapping(get_config(key));
+            fill_name_to_path_mapping(get_config(key, path_to_metadata));
             cached = cached_bmis_.emplace_hint(cached, key, File(key, this));
         }
         return cached->second;
@@ -15,7 +17,7 @@ namespace ifc
 
     File const& Environment::get_module_by_name(std::string const& name)
     {
-        return get_module_by_bmi_path(module_name_to_bmi_path_[name]);
+        return get_module_by_bmi_path(module_name_to_bmi_path_[name], std::nullopt);
     }
 
     void Environment::fill_name_to_path_mapping(Config config)

--- a/lib/msvc/include/ifc/MSVCEnvironment.h
+++ b/lib/msvc/include/ifc/MSVCEnvironment.h
@@ -7,6 +7,6 @@ namespace ifc
     class MSVCEnvironment final : public Environment
     {
     protected:
-        Config get_config(std::string const& path_to_bmi) const override;
+        Config get_config(std::string const& path_to_bmi, std::optional<std::string> const&) const override;
     };
 }

--- a/lib/msvc/src/MSVCEnvironment.cpp
+++ b/lib/msvc/src/MSVCEnvironment.cpp
@@ -5,13 +5,12 @@
 #include <filesystem>
 #include <fstream>
 
-ifc::Environment::Config ifc::MSVCEnvironment::get_config(std::string const& path_to_bmi) const
+ifc::Environment::Config ifc::MSVCEnvironment::get_config(std::string const& path_to_bmi, std::optional<std::string> const& path_to_metadata) const
 {
-    std::string path_to_metadata = path_to_bmi + ".d.json";
-
-    std::ifstream file(path_to_metadata);
+    const std::string metadata_path = path_to_metadata.value_or(path_to_bmi + ".d.json");
+    std::ifstream file(metadata_path);
     if (!file)
-        throw std::runtime_error("metadata is not found by path '" + path_to_metadata + "'");
+        throw std::runtime_error("metadata is not found by path '" + metadata_path + "'");
 
     nlohmann::json metadata;
     file >> metadata;


### PR DESCRIPTION
This PR sits on top of https://github.com/AndreyG/ifc-reader/pull/6 because I can't build (currently) without this.

This PR attempt to resolve #8, but adding support for an additional, optional argument to the environment class, that allows the user to provide a metadata path as an optional argument `dump-decls`.

This means you go from:

```
~/clones/ifc-reader/source_deps_file/build/examples/dump-decls/dump-decls moo.ifc
metadata is not found by path 'moo.ifc.d.json'
```

to:

```
~/clones/ifc-reader/source_deps_file/build/examples/dump-decls/dump-decls moo.ifc mod_moo.cpp.json
IFC Version: 0.40
File contains 13 partitions
Global Scope Index: 1
Total declarations count: 2
Scopes count: 2
Count of declarations from all scopes: 2
-------------------------------------- Global Scope --------------------------------------
Class 'Moo' {
  Method 'moo', type: short()
}
```

where: `mod_moo.cpp.json` is that name that `cl.exe` generates when you call:

```
cl.exe /W4 /WX /experimental:module /interface /sourceDependencies . /std:c++latest /EHsc /MD /c mod_moo.cpp
```


