### PR TITLE
tune: Make .d.json as optional (when compiled as API interface)

### DIFF
--- a/examples/dump-decls/main.cpp
+++ b/examples/dump-decls/main.cpp
@@ -23,8 +23,15 @@ int main(int argc, char* argv[])
 
     try
     {
-        ifc::MSVCEnvironment env(path_to_ifc + ".d.json");
-        ifc::File const & file = env.get_module_by_bmi_path(path_to_ifc);
+        std::filesystem::path f(path_to_ifc + ".d.json");
+        std::shared_ptr<ifc::MSVCEnvironment> env;
+        
+        if(std::filesystem::exists(f))
+            env.reset(new ifc::MSVCEnvironment(f.string().c_str()));
+        else
+            env.reset(new ifc::MSVCEnvironment);
+
+        ifc::File const & file = env->get_module_by_bmi_path(path_to_ifc);
 
         ifc::FileHeader const & header = file.header();
         std::cout << "IFC Version: " << header.major_version << "." << header.minor_version << "\n"

--- a/lib/core/include/ifc/Environment.h
+++ b/lib/core/include/ifc/Environment.h
@@ -35,6 +35,7 @@ namespace ifc
             std::vector<Module> imported_modules;
         };
 
+        Environment();
         Environment(Config);
 
     private:

--- a/lib/core/src/Environment.cpp
+++ b/lib/core/src/Environment.cpp
@@ -18,6 +18,10 @@ namespace ifc
         return get_module_by_bmi_path(module_name_to_bmi_path_[name]);
     }
 
+    Environment::Environment()
+    {
+    }
+
     Environment::Environment(Config config)
     {
         for (auto & [header, bmi] : config.imported_header_units)

--- a/lib/msvc/include/ifc/MSVCEnvironment.h
+++ b/lib/msvc/include/ifc/MSVCEnvironment.h
@@ -7,6 +7,11 @@ namespace ifc
     class MSVCEnvironment final : public Environment
     {
     public:
+        MSVCEnvironment()
+            : Environment()
+        {
+        }
+
         MSVCEnvironment(std::string const& path_to_config)
             : Environment(read_config(path_to_config))
         {}


### PR DESCRIPTION
https://github.com/NTSFka/CMakeCxxModules.git

can be compiled resulting only in one .ifc file without .d.json - add support for loading that one.