### PR TITLE
Fixed memory corruption while requesting attributes for a declaration

### DIFF
--- a/lib/core/src/File.cpp
+++ b/lib/core/src/File.cpp
@@ -374,7 +374,7 @@ namespace ifc
     }
 
     template<typename RetType, typename Value>
-    Value get_value(DeclIndex declaration, std::unordered_map<DeclIndex, Value> const & map)
+    RetType get_value(DeclIndex declaration, std::unordered_map<DeclIndex, Value> const & map)
     {
         if (auto it = map.find(declaration); it != map.end())
             return it->second;


### PR DESCRIPTION
Due to a typo the `span` was being created from a temporary copy of `Value` instead of creating the `span` in place.