### PR TITLE
Removed ifc::File's macro's and made the caching threadsafe.

### DIFF
--- a/lib/core/include/ifc/File.h
+++ b/lib/core/include/ifc/File.h
@@ -34,142 +34,143 @@ namespace ifc
 
         std::byte const* get_data_pointer(PartitionSummary const&) const;
 
-#define DECLARE_PARTITION_GETTER(ElementType, IndexType, Property)  \
-    public:                                                         \
-    Partition<ElementType, IndexType> Property() const;        \
-    private:                                                        \
+#define DECLARE_PARTITION_GETTER(ElementType, IndexType, Property)                          \
+    public:                                                                                 \
+        Partition<ElementType, IndexType> Property() const;                                 \
+    private:                                                                                \
         mutable std::optional<Partition<ElementType, IndexType>> cached_ ## Property ## _ ;
 
-    // Declarations
-    DECLARE_PARTITION_GETTER(Declaration, Index, declarations)
+        // Declarations
+        DECLARE_PARTITION_GETTER(Declaration,           Index,          declarations)
+    
+        DECLARE_PARTITION_GETTER(ScopeDeclaration,      DeclIndex,      scope_declarations)
+        DECLARE_PARTITION_GETTER(TemplateDeclaration,   DeclIndex,      template_declarations)
+        DECLARE_PARTITION_GETTER(PartialSpecialization, DeclIndex,      partial_specializations)
+        DECLARE_PARTITION_GETTER(Specialization,        DeclIndex,      specializations)
+        DECLARE_PARTITION_GETTER(UsingDeclaration,      DeclIndex,      using_declarations)
+        DECLARE_PARTITION_GETTER(Enumeration,           DeclIndex,      enumerations)
+        DECLARE_PARTITION_GETTER(Enumerator,            DeclIndex,      enumerators)
+        DECLARE_PARTITION_GETTER(AliasDeclaration,      DeclIndex,      alias_declarations)
+        DECLARE_PARTITION_GETTER(DeclReference,         DeclIndex,      decl_references)
+        DECLARE_PARTITION_GETTER(FunctionDeclaration,   DeclIndex,      functions)
+        DECLARE_PARTITION_GETTER(MethodDeclaration,     DeclIndex,      methods)
+        DECLARE_PARTITION_GETTER(Constructor,           DeclIndex,      constructors)
+        DECLARE_PARTITION_GETTER(Destructor,            DeclIndex,      destructors)
+        DECLARE_PARTITION_GETTER(VariableDeclaration,   DeclIndex,      variables)
+        DECLARE_PARTITION_GETTER(FieldDeclaration,      DeclIndex,      fields)
+        DECLARE_PARTITION_GETTER(ParameterDeclaration,  DeclIndex,      parameters)
+        DECLARE_PARTITION_GETTER(Concept,               DeclIndex,      concepts)
+        DECLARE_PARTITION_GETTER(FriendDeclaration,     DeclIndex,      friends)
+        DECLARE_PARTITION_GETTER(IntrinsicDeclaration,  DeclIndex,      intrinsic_declarations)
 
-    DECLARE_PARTITION_GETTER(ScopeDeclaration, DeclIndex, scope_declarations)
-    DECLARE_PARTITION_GETTER(TemplateDeclaration, DeclIndex, template_declarations)
-    DECLARE_PARTITION_GETTER(PartialSpecialization, DeclIndex, partial_specializations)
-    DECLARE_PARTITION_GETTER(Specialization, DeclIndex, specializations)
-    DECLARE_PARTITION_GETTER(UsingDeclaration, DeclIndex, using_declarations)
-    DECLARE_PARTITION_GETTER(Enumeration, DeclIndex, enumerations)
-    DECLARE_PARTITION_GETTER(Enumerator, DeclIndex, enumerators)
-    DECLARE_PARTITION_GETTER(AliasDeclaration, DeclIndex, alias_declarations)
-    DECLARE_PARTITION_GETTER(DeclReference, DeclIndex, decl_references)
-    DECLARE_PARTITION_GETTER(FunctionDeclaration, DeclIndex, functions)
-    DECLARE_PARTITION_GETTER(MethodDeclaration, DeclIndex, methods)
-    DECLARE_PARTITION_GETTER(Constructor, DeclIndex, constructors)
-    DECLARE_PARTITION_GETTER(Destructor, DeclIndex, destructors)
-    DECLARE_PARTITION_GETTER(VariableDeclaration, DeclIndex, variables)
-    DECLARE_PARTITION_GETTER(ParameterDeclaration, DeclIndex, parameters)
-    DECLARE_PARTITION_GETTER(FieldDeclaration, DeclIndex, fields)
-    DECLARE_PARTITION_GETTER(FriendDeclaration, DeclIndex, friends)
-    DECLARE_PARTITION_GETTER(Concept, DeclIndex, concepts)
-    DECLARE_PARTITION_GETTER(IntrinsicDeclaration, DeclIndex,  intrinsic_declarations)
+        DECLARE_PARTITION_GETTER(SpecializationForm,    SpecFormIndex,  specialization_forms)
 
-    DECLARE_PARTITION_GETTER(SpecializationForm, SpecFormIndex, specialization_forms)
+        // Types
+        DECLARE_PARTITION_GETTER(FundamentalType,    TypeIndex,  fundamental_types)
+        DECLARE_PARTITION_GETTER(DesignatedType,     TypeIndex,  designated_types)
+        DECLARE_PARTITION_GETTER(TorType,            TypeIndex,  tor_types)
+        DECLARE_PARTITION_GETTER(SyntacticType,      TypeIndex,  syntactic_types)
+        DECLARE_PARTITION_GETTER(ExpansionType,      TypeIndex,  expansion_types)
+        DECLARE_PARTITION_GETTER(PointerType,        TypeIndex,  pointer_types)
+        DECLARE_PARTITION_GETTER(FunctionType,       TypeIndex,  function_types)
+        DECLARE_PARTITION_GETTER(MethodType,         TypeIndex,  method_types)
+        DECLARE_PARTITION_GETTER(ArrayType,          TypeIndex,  array_types)
+        DECLARE_PARTITION_GETTER(BaseType,           TypeIndex,  base_types)
+        DECLARE_PARTITION_GETTER(TupleType,          TypeIndex,  tuple_types)
+        DECLARE_PARTITION_GETTER(LvalueReference,    TypeIndex,  lvalue_references)
+        DECLARE_PARTITION_GETTER(RvalueReference,    TypeIndex,  rvalue_references)
+        DECLARE_PARTITION_GETTER(QualifiedType,      TypeIndex,  qualified_types)
+        DECLARE_PARTITION_GETTER(ForallType,         TypeIndex,  forall_types)
+        DECLARE_PARTITION_GETTER(SyntaxType,         TypeIndex,  syntax_types)
+        DECLARE_PARTITION_GETTER(PlaceholderType,    TypeIndex,  placeholder_types)
+        DECLARE_PARTITION_GETTER(TypenameType,       TypeIndex,  typename_types)
+        DECLARE_PARTITION_GETTER(DecltypeType,       TypeIndex,  decltype_types)
 
-    // Types
-    DECLARE_PARTITION_GETTER(FundamentalType, TypeIndex, fundamental_types)
-    DECLARE_PARTITION_GETTER(DesignatedType, TypeIndex, designated_types)
-    DECLARE_PARTITION_GETTER(TorType, TypeIndex, tor_types)
-    DECLARE_PARTITION_GETTER(SyntacticType, TypeIndex, syntactic_types)
-    DECLARE_PARTITION_GETTER(ExpansionType, TypeIndex, expansion_types)
-    DECLARE_PARTITION_GETTER(PointerType, TypeIndex, pointer_types)
-    DECLARE_PARTITION_GETTER(FunctionType, TypeIndex, function_types)
-    DECLARE_PARTITION_GETTER(MethodType, TypeIndex, method_types)
-    DECLARE_PARTITION_GETTER(ArrayType, TypeIndex, array_types)
-    DECLARE_PARTITION_GETTER(BaseType, TypeIndex, base_types)
-    DECLARE_PARTITION_GETTER(TupleType, TypeIndex, tuple_types)
-    DECLARE_PARTITION_GETTER(LvalueReference, TypeIndex, lvalue_references)
-    DECLARE_PARTITION_GETTER(RvalueReference, TypeIndex, rvalue_references)
-    DECLARE_PARTITION_GETTER(QualifiedType, TypeIndex, qualified_types)
-    DECLARE_PARTITION_GETTER(ForallType, TypeIndex, forall_types)
-    DECLARE_PARTITION_GETTER(SyntaxType, TypeIndex, syntax_types)
-    DECLARE_PARTITION_GETTER(PlaceholderType, TypeIndex, placeholder_types)
-    DECLARE_PARTITION_GETTER(TypenameType, TypeIndex, typename_types)
-    DECLARE_PARTITION_GETTER(DecltypeType, TypeIndex, decltype_types)
+        // Attributes
+        DECLARE_PARTITION_GETTER(AttrBasic,      AttrIndex,  basic_attributes)
+        DECLARE_PARTITION_GETTER(AttrScoped,     AttrIndex,  scoped_attributes)
+        DECLARE_PARTITION_GETTER(AttrLabeled,    AttrIndex,  labeled_attributes)
+        DECLARE_PARTITION_GETTER(AttrCalled,     AttrIndex,  called_attributes)
+        DECLARE_PARTITION_GETTER(AttrExpanded,   AttrIndex,  expanded_attributes)
+        DECLARE_PARTITION_GETTER(AttrFactored,   AttrIndex,  factored_attributes)
+        DECLARE_PARTITION_GETTER(AttrElaborated, AttrIndex,  elaborated_attributes)
+        DECLARE_PARTITION_GETTER(AttrTuple,      AttrIndex,  tuple_attributes)
 
-    // Attributes
-    DECLARE_PARTITION_GETTER(AttrBasic, AttrIndex, basic_attributes)
-    DECLARE_PARTITION_GETTER(AttrScoped, AttrIndex, scoped_attributes)
-    DECLARE_PARTITION_GETTER(AttrLabeled, AttrIndex, labeled_attributes)
-    DECLARE_PARTITION_GETTER(AttrCalled, AttrIndex, called_attributes)
-    DECLARE_PARTITION_GETTER(AttrExpanded, AttrIndex, expanded_attributes)
-    DECLARE_PARTITION_GETTER(AttrFactored, AttrIndex, factored_attributes)
-    DECLARE_PARTITION_GETTER(AttrElaborated, AttrIndex, elaborated_attributes)
-    DECLARE_PARTITION_GETTER(AttrTuple, AttrIndex, tuple_attributes)
+        // Expressions
+        DECLARE_PARTITION_GETTER(LiteralExpression,             ExprIndex,      literal_expressions)
+        DECLARE_PARTITION_GETTER(TypeExpression,                ExprIndex,      type_expressions)
+        DECLARE_PARTITION_GETTER(NamedDecl,                     ExprIndex,      decl_expressions)
+        DECLARE_PARTITION_GETTER(UnqualifiedId,                 ExprIndex,      unqualified_id_expressions)
+        DECLARE_PARTITION_GETTER(TemplateId,                    ExprIndex,      template_ids)
+        DECLARE_PARTITION_GETTER(TemplateReference,             ExprIndex,      template_references)
+        DECLARE_PARTITION_GETTER(MonadExpression,               ExprIndex,      monad_expressions)
+        DECLARE_PARTITION_GETTER(DyadExpression,                ExprIndex,      dyad_expressions)
+        DECLARE_PARTITION_GETTER(StringExpression,              ExprIndex,      string_expressions)
+        DECLARE_PARTITION_GETTER(CallExpression,                ExprIndex,      call_expressions)
+        DECLARE_PARTITION_GETTER(SizeofExpression,              ExprIndex,      sizeof_expressions)
+        DECLARE_PARTITION_GETTER(AlignofExpression,             ExprIndex,      alignof_expressions)
+        DECLARE_PARTITION_GETTER(RequiresExpression,            ExprIndex,      requires_expressions)
+        DECLARE_PARTITION_GETTER(TupleExpression,               ExprIndex,      tuple_expressions)
+        DECLARE_PARTITION_GETTER(PathExpression,                ExprIndex,      path_expressions)
+        DECLARE_PARTITION_GETTER(ReadExpression,                ExprIndex,      read_expressions)
+        DECLARE_PARTITION_GETTER(SyntaxTreeExpression,          ExprIndex,      syntax_tree_expressions)
 
-    // Expressions
-    DECLARE_PARTITION_GETTER(LiteralExpression, ExprIndex, literal_expressions)
-    DECLARE_PARTITION_GETTER(TypeExpression, ExprIndex, type_expressions)
-    DECLARE_PARTITION_GETTER(NamedDecl, ExprIndex, decl_expressions)
-    DECLARE_PARTITION_GETTER(UnqualifiedId, ExprIndex, unqualified_id_expressions)
-    DECLARE_PARTITION_GETTER(TemplateId, ExprIndex, template_ids)
-    DECLARE_PARTITION_GETTER(TemplateReference, ExprIndex, template_references)
-    DECLARE_PARTITION_GETTER(MonadExpression, ExprIndex, monad_expressions)
-    DECLARE_PARTITION_GETTER(DyadExpression, ExprIndex, dyad_expressions)
-    DECLARE_PARTITION_GETTER(StringExpression, ExprIndex, string_expressions)
-    DECLARE_PARTITION_GETTER(CallExpression, ExprIndex, call_expressions)
-    DECLARE_PARTITION_GETTER(SizeofExpression, ExprIndex, sizeof_expressions)
-    DECLARE_PARTITION_GETTER(AlignofExpression, ExprIndex, alignof_expressions)
-    DECLARE_PARTITION_GETTER(RequiresExpression, ExprIndex, requires_expressions)
-    DECLARE_PARTITION_GETTER(TupleExpression, ExprIndex, tuple_expressions)
-    DECLARE_PARTITION_GETTER(PathExpression, ExprIndex, path_expressions)
-    DECLARE_PARTITION_GETTER(ReadExpression, ExprIndex, read_expressions)
-    DECLARE_PARTITION_GETTER(SyntaxTreeExpression, ExprIndex, syntax_tree_expressions)
+        DECLARE_PARTITION_GETTER(ExpressionListExpression,      ExprIndex,      expression_lists)
+        DECLARE_PARTITION_GETTER(QualifiedNameExpression,       ExprIndex,      qualified_name_expressions)
+        DECLARE_PARTITION_GETTER(PackedTemplateArguments,       ExprIndex,      packed_template_arguments)
+        DECLARE_PARTITION_GETTER(ProductValueTypeExpression,    ExprIndex,      product_value_type_expressions)
 
-    DECLARE_PARTITION_GETTER(ExpressionListExpression, ExprIndex, expression_lists)
-    DECLARE_PARTITION_GETTER(QualifiedNameExpression, ExprIndex, qualified_name_expressions)
-    DECLARE_PARTITION_GETTER(PackedTemplateArguments, ExprIndex, packed_template_arguments)
-    DECLARE_PARTITION_GETTER(ProductValueTypeExpression, ExprIndex, product_value_type_expressions)
+        DECLARE_PARTITION_GETTER(StringLiteral,                 StringIndex,    string_literal_expressions)
 
-    DECLARE_PARTITION_GETTER(StringLiteral, StringIndex, string_literal_expressions)
+        // Heaps
+        DECLARE_PARTITION_GETTER(TypeIndex,     Index,  type_heap)
+        DECLARE_PARTITION_GETTER(ExprIndex,     Index,  expr_heap)
+        DECLARE_PARTITION_GETTER(AttrIndex,     Index,  attr_heap)
+        DECLARE_PARTITION_GETTER(SyntaxIndex,   Index,  syntax_heap)
 
-    // Heaps
-    DECLARE_PARTITION_GETTER(TypeIndex, Index, type_heap)
-    DECLARE_PARTITION_GETTER(ExprIndex, Index, expr_heap)
-    DECLARE_PARTITION_GETTER(AttrIndex, Index, attr_heap)
-    DECLARE_PARTITION_GETTER(SyntaxIndex, Index, syntax_heap)
+        // Names
+        DECLARE_PARTITION_GETTER(OperatorFunctionName,   NameIndex,  operator_names)
+        DECLARE_PARTITION_GETTER(SpecializationName,     NameIndex,  specialization_names)
+        DECLARE_PARTITION_GETTER(LiteralName,            NameIndex,  literal_names)
 
-    // Names
-    DECLARE_PARTITION_GETTER(OperatorFunctionName, NameIndex, operator_names)
-    DECLARE_PARTITION_GETTER(SpecializationName,   NameIndex, specialization_names)
-    DECLARE_PARTITION_GETTER(LiteralName,          NameIndex, literal_names)
+        // Charts
+        DECLARE_PARTITION_GETTER(ChartUnilevel,      ChartIndex, unilevel_charts)
+        DECLARE_PARTITION_GETTER(ChartMultilevel,    ChartIndex, multilevel_charts)
 
-    // Charts
-    DECLARE_PARTITION_GETTER(ChartUnilevel,     ChartIndex, unilevel_charts)
-    DECLARE_PARTITION_GETTER(ChartMultilevel,   ChartIndex, multilevel_charts)
+        // Literals
+        DECLARE_PARTITION_GETTER(IntegerLiteral, LitIndex,   integer_literals)
+        DECLARE_PARTITION_GETTER(FPLiteral,      LitIndex,   fp_literals)
+        
+        // Syntax Trees
+        DECLARE_PARTITION_GETTER(SimpleTypeSpecifier,           SyntaxIndex,    simple_type_specifiers)
+        DECLARE_PARTITION_GETTER(DecltypeSpecifier,             SyntaxIndex,    decltype_specifiers)
+        DECLARE_PARTITION_GETTER(TypeSpecifierSeq,              SyntaxIndex,    type_specifier_seq_syntax_trees)
+        DECLARE_PARTITION_GETTER(DeclSpecifierSeq,              SyntaxIndex,    decl_specifier_seq_syntax_trees)
+        DECLARE_PARTITION_GETTER(TypeIdSyntax,                  SyntaxIndex,    typeid_syntax_trees)
+        DECLARE_PARTITION_GETTER(DeclaratorSyntax,              SyntaxIndex,    declarator_syntax_trees)
+        DECLARE_PARTITION_GETTER(PointerDeclaratorSyntax,       SyntaxIndex,    pointer_declarator_syntax_trees)
+        DECLARE_PARTITION_GETTER(FunctionDeclaratorSyntax,      SyntaxIndex,    function_declarator_syntax_trees)
+        DECLARE_PARTITION_GETTER(ParameterDeclaratorSyntax,     SyntaxIndex,    parameter_declarator_syntax_trees)
+        DECLARE_PARTITION_GETTER(ExpressionSyntax,              SyntaxIndex,    expression_syntax_trees)
+        DECLARE_PARTITION_GETTER(RequiresClauseSyntax,          SyntaxIndex,    requires_clause_syntax_trees)
+        DECLARE_PARTITION_GETTER(SimpleRequirementSyntax,       SyntaxIndex,    simple_requirement_syntax_trees)
+        DECLARE_PARTITION_GETTER(TypeRequirementSyntax,         SyntaxIndex,    type_requirement_syntax_trees)
+        DECLARE_PARTITION_GETTER(NestedRequirementSyntax,       SyntaxIndex,    nested_requirement_syntax_trees)
+        DECLARE_PARTITION_GETTER(CompoundRequirementSyntax,     SyntaxIndex,    compound_requirement_syntax_trees)
+        DECLARE_PARTITION_GETTER(RequirementBodySyntax,         SyntaxIndex,    requirement_body_syntax_trees)
+        DECLARE_PARTITION_GETTER(TypeTemplateArgumentSyntax,    SyntaxIndex,    type_template_argument_syntax_trees)
+        DECLARE_PARTITION_GETTER(TemplateArgumentListSyntax,    SyntaxIndex,    template_argument_list_syntax_trees)
+        DECLARE_PARTITION_GETTER(TemplateIdSyntax,              SyntaxIndex,    templateid_syntax_trees)
+        DECLARE_PARTITION_GETTER(TypeTraitIntrinsicSyntax,      SyntaxIndex,    type_trait_intrinsic_syntax_trees)
+        DECLARE_PARTITION_GETTER(TupleSyntax,                   SyntaxIndex,    tuple_syntax_trees)
 
-    // Literals
-    DECLARE_PARTITION_GETTER(IntegerLiteral,    LitIndex,   integer_literals)
-    DECLARE_PARTITION_GETTER(FPLiteral,         LitIndex,   fp_literals)
 
-    // Syntax Trees
-    DECLARE_PARTITION_GETTER(SimpleTypeSpecifier, SyntaxIndex, simple_type_specifiers)
-    DECLARE_PARTITION_GETTER(DecltypeSpecifier, SyntaxIndex, decltype_specifiers)
-    DECLARE_PARTITION_GETTER(TypeSpecifierSeq, SyntaxIndex, type_specifier_seq_syntax_trees)
-    DECLARE_PARTITION_GETTER(DeclSpecifierSeq, SyntaxIndex, decl_specifier_seq_syntax_trees)
-    DECLARE_PARTITION_GETTER(TypeIdSyntax, SyntaxIndex, typeid_syntax_trees)
-    DECLARE_PARTITION_GETTER(DeclaratorSyntax, SyntaxIndex, declarator_syntax_trees)
-    DECLARE_PARTITION_GETTER(PointerDeclaratorSyntax, SyntaxIndex, pointer_declarator_syntax_trees)
-    DECLARE_PARTITION_GETTER(FunctionDeclaratorSyntax, SyntaxIndex, function_declarator_syntax_trees)
-    DECLARE_PARTITION_GETTER(ParameterDeclaratorSyntax, SyntaxIndex, parameter_declarator_syntax_trees)
-    DECLARE_PARTITION_GETTER(ExpressionSyntax, SyntaxIndex, expression_syntax_trees)
-    DECLARE_PARTITION_GETTER(RequiresClauseSyntax, SyntaxIndex, requires_clause_syntax_trees)
-    DECLARE_PARTITION_GETTER(SimpleRequirementSyntax, SyntaxIndex, simple_requirement_syntax_trees)
-    DECLARE_PARTITION_GETTER(TypeRequirementSyntax, SyntaxIndex, type_requirement_syntax_trees)
-    DECLARE_PARTITION_GETTER(NestedRequirementSyntax, SyntaxIndex, nested_requirement_syntax_trees)
-    DECLARE_PARTITION_GETTER(CompoundRequirementSyntax, SyntaxIndex, compound_requirement_syntax_trees)
-    DECLARE_PARTITION_GETTER(RequirementBodySyntax, SyntaxIndex, requirement_body_syntax_trees)
-    DECLARE_PARTITION_GETTER(TypeTemplateArgumentSyntax, SyntaxIndex, type_template_argument_syntax_trees)
-    DECLARE_PARTITION_GETTER(TemplateArgumentListSyntax, SyntaxIndex, template_argument_list_syntax_trees)
-    DECLARE_PARTITION_GETTER(TemplateIdSyntax, SyntaxIndex, templateid_syntax_trees)
-    DECLARE_PARTITION_GETTER(TypeTraitIntrinsicSyntax, SyntaxIndex, type_trait_intrinsic_syntax_trees)
-    DECLARE_PARTITION_GETTER(TupleSyntax, SyntaxIndex, tuple_syntax_trees)
+        // Module References
+        DECLARE_PARTITION_GETTER(ModuleReference,   Index,  imported_modules);
+        DECLARE_PARTITION_GETTER(ModuleReference,   Index,  exported_modules);
 
-    // Module References
-    DECLARE_PARTITION_GETTER(ModuleReference, Index, imported_modules);
-    DECLARE_PARTITION_GETTER(ModuleReference, Index, exported_modules);
-
-    // Deducation guides
-    Partition<DeclIndex> deduction_guides() const;
+        // Deducation guides
+        DECLARE_PARTITION_GETTER(DeclIndex, uint32_t,   deduction_guides);
 
 #undef DECLARE_PARTITION_GETTER
 

--- a/lib/core/include/ifc/File.h
+++ b/lib/core/include/ifc/File.h
@@ -34,175 +34,135 @@ namespace ifc
 
         std::byte const* get_data_pointer(PartitionSummary const&) const;
 
-#define DECLARE_UNTYPED_PARTITION_GETTER(ElementType, IndexType, Property)  \
-    public:                                                                 \
-    Partition<ElementType, IndexType> Property() const;                     \
-    private:                                                                \
-        mutable std::optional<Partition<ElementType, IndexType>> cached_ ## Property ## _ ;
-
-#define DECLARE_PARTITION_GETTER(ElementType, IndexType, Property)  \
-    public:                                                         \
-    TypedPartition<ElementType, IndexType> Property() const;        \
-    private:                                                        \
-        mutable std::optional<Partition<ElementType, IndexType>> cached_ ## Property ## _ ;
-
         // Declarations
-        DECLARE_UNTYPED_PARTITION_GETTER(Declaration, Index, declarations)
+        Partition<Declaration, Index>               declarations() const;
 
-#define DECLARE_DECL_PARTITION_GETTER(DeclType, DeclName) \
-    DECLARE_PARTITION_GETTER(DeclType, DeclIndex, DeclName)
+        Partition<ScopeDeclaration, DeclIndex>      scope_declarations() const;
+        Partition<TemplateDeclaration, DeclIndex>   template_declarations() const;
+        Partition<PartialSpecialization, DeclIndex> partial_specializations() const;
+        Partition<Specialization, DeclIndex>        specializations() const;
+        Partition<UsingDeclaration, DeclIndex>      using_declarations() const;
+        Partition<Enumeration, DeclIndex>           enumerations() const;
+        Partition<Enumerator, DeclIndex>            enumerators() const;
+        Partition<AliasDeclaration, DeclIndex>      alias_declarations() const;
+        Partition<DeclReference, DeclIndex>         decl_references() const;
+        Partition<FunctionDeclaration, DeclIndex>   functions() const;
+        Partition<MethodDeclaration, DeclIndex>     methods() const;
+        Partition<Constructor, DeclIndex>           constructors() const;
+        Partition<Destructor, DeclIndex>            destructors() const;
+        Partition<VariableDeclaration, DeclIndex>   variables() const;
+        Partition<ParameterDeclaration, DeclIndex>  parameters() const;
+        Partition<FieldDeclaration, DeclIndex>      fields() const;
+        Partition<FriendDeclaration, DeclIndex>     friends() const;
+        Partition<Concept, DeclIndex>               concepts() const;
+        Partition<IntrinsicDeclaration, DeclIndex>  intrinsic_declarations() const;
 
-        DECLARE_DECL_PARTITION_GETTER(ScopeDeclaration,      scope_declarations)
-        DECLARE_DECL_PARTITION_GETTER(TemplateDeclaration,   template_declarations)
-        DECLARE_DECL_PARTITION_GETTER(PartialSpecialization, partial_specializations)
-        DECLARE_DECL_PARTITION_GETTER(Specialization,        specializations)
-        DECLARE_DECL_PARTITION_GETTER(UsingDeclaration,      using_declarations)
-        DECLARE_DECL_PARTITION_GETTER(Enumeration,           enumerations)
-        DECLARE_DECL_PARTITION_GETTER(Enumerator,            enumerators)
-        DECLARE_DECL_PARTITION_GETTER(AliasDeclaration,      alias_declarations)
-        DECLARE_DECL_PARTITION_GETTER(DeclReference,         decl_references)
-        DECLARE_DECL_PARTITION_GETTER(FunctionDeclaration,   functions)
-        DECLARE_DECL_PARTITION_GETTER(MethodDeclaration,     methods)
-        DECLARE_DECL_PARTITION_GETTER(Constructor,           constructors)
-        DECLARE_DECL_PARTITION_GETTER(Destructor,            destructors)
-        DECLARE_DECL_PARTITION_GETTER(VariableDeclaration,   variables)
-        DECLARE_DECL_PARTITION_GETTER(ParameterDeclaration,  parameters)
-        DECLARE_DECL_PARTITION_GETTER(FieldDeclaration,      fields)
-        DECLARE_DECL_PARTITION_GETTER(FriendDeclaration,     friends)
-        DECLARE_DECL_PARTITION_GETTER(Concept,               concepts)
-        DECLARE_DECL_PARTITION_GETTER(IntrinsicDeclaration,  intrinsic_declarations)
-
-#undef DECLARE_DECL_PARTITION_GETTER
-
-        DECLARE_UNTYPED_PARTITION_GETTER(SpecializationForm, SpecFormIndex, specialization_forms)
+        Partition<SpecializationForm, SpecFormIndex> specialization_forms() const;
 
         // Types
-#define DECLARE_TYPE_PARTITION_GETTER(Type, TypeName) \
-    DECLARE_PARTITION_GETTER(Type, TypeIndex, TypeName)
-
-        DECLARE_TYPE_PARTITION_GETTER(FundamentalType,    fundamental_types)
-        DECLARE_TYPE_PARTITION_GETTER(DesignatedType,     designated_types)
-        DECLARE_TYPE_PARTITION_GETTER(TorType,            tor_types)
-        DECLARE_TYPE_PARTITION_GETTER(SyntacticType,      syntactic_types)
-        DECLARE_TYPE_PARTITION_GETTER(ExpansionType,      expansion_types)
-        DECLARE_TYPE_PARTITION_GETTER(PointerType,        pointer_types)
-        DECLARE_TYPE_PARTITION_GETTER(FunctionType,       function_types)
-        DECLARE_TYPE_PARTITION_GETTER(MethodType,         method_types)
-        DECLARE_TYPE_PARTITION_GETTER(ArrayType,          array_types)
-        DECLARE_TYPE_PARTITION_GETTER(BaseType,           base_types)
-        DECLARE_TYPE_PARTITION_GETTER(TupleType,          tuple_types)
-        DECLARE_TYPE_PARTITION_GETTER(LvalueReference,    lvalue_references)
-        DECLARE_TYPE_PARTITION_GETTER(RvalueReference,    rvalue_references)
-        DECLARE_TYPE_PARTITION_GETTER(QualifiedType,      qualified_types)
-        DECLARE_TYPE_PARTITION_GETTER(ForallType,         forall_types)
-        DECLARE_TYPE_PARTITION_GETTER(SyntaxType,         syntax_types)
-        DECLARE_TYPE_PARTITION_GETTER(PlaceholderType,    placeholder_types)
-        DECLARE_TYPE_PARTITION_GETTER(TypenameType,       typename_types)
-        DECLARE_TYPE_PARTITION_GETTER(DecltypeType,       decltype_types)
-
-#undef DECLARE_TYPE_PARTITION_GETTER
+        Partition<FundamentalType, TypeIndex>    fundamental_types() const;
+        Partition<DesignatedType, TypeIndex>     designated_types() const;
+        Partition<TorType, TypeIndex>            tor_types() const;
+        Partition<SyntacticType, TypeIndex>      syntactic_types() const;
+        Partition<ExpansionType, TypeIndex>      expansion_types() const;
+        Partition<PointerType, TypeIndex>        pointer_types() const;
+        Partition<FunctionType, TypeIndex>       function_types() const;
+        Partition<MethodType, TypeIndex>         method_types() const;
+        Partition<ArrayType, TypeIndex>          array_types() const;
+        Partition<BaseType, TypeIndex>           base_types() const;
+        Partition<TupleType, TypeIndex>          tuple_types() const;
+        Partition<LvalueReference, TypeIndex>    lvalue_references() const;
+        Partition<RvalueReference, TypeIndex>    rvalue_references() const;
+        Partition<QualifiedType, TypeIndex>      qualified_types() const;
+        Partition<ForallType, TypeIndex>         forall_types() const;
+        Partition<SyntaxType, TypeIndex>         syntax_types() const;
+        Partition<PlaceholderType, TypeIndex>    placeholder_types() const;
+        Partition<TypenameType, TypeIndex>       typename_types() const;
+        Partition<DecltypeType, TypeIndex>       decltype_types() const;
 
         // Attributes
-#define DECLARE_ATTR_PARTITION_GETTER(ExprType, ExprName) \
-    DECLARE_PARTITION_GETTER(ExprType, AttrIndex, ExprName)
-
-        DECLARE_ATTR_PARTITION_GETTER(AttrBasic, basic_attributes)
-        DECLARE_ATTR_PARTITION_GETTER(AttrScoped, scoped_attributes)
-        DECLARE_ATTR_PARTITION_GETTER(AttrLabeled, labeled_attributes)
-        DECLARE_ATTR_PARTITION_GETTER(AttrCalled, called_attributes)
-        DECLARE_ATTR_PARTITION_GETTER(AttrExpanded, expanded_attributes)
-        DECLARE_ATTR_PARTITION_GETTER(AttrFactored, factored_attributes)
-        DECLARE_ATTR_PARTITION_GETTER(AttrElaborated, elaborated_attributes)
-        DECLARE_ATTR_PARTITION_GETTER(AttrTuple, tuple_attributes)
-
-#undef DECLARE_ATTR_PARTITION_GETTER
+        Partition<AttrBasic, AttrIndex>         basic_attributes() const;
+        Partition<AttrScoped, AttrIndex>        scoped_attributes() const;
+        Partition<AttrLabeled, AttrIndex>       labeled_attributes() const;
+        Partition<AttrCalled, AttrIndex>        called_attributes() const;
+        Partition<AttrExpanded, AttrIndex>      expanded_attributes() const;
+        Partition<AttrFactored, AttrIndex>      factored_attributes() const;
+        Partition<AttrElaborated, AttrIndex>    elaborated_attributes() const;
+        Partition<AttrTuple, AttrIndex>         tuple_attributes() const;
 
         // Expressions
-#define DECLARE_EXPR_PARTITION_GETTER(ExprType, ExprName) \
-    DECLARE_PARTITION_GETTER(ExprType, ExprIndex, ExprName)
+        Partition<LiteralExpression, ExprIndex>             literal_expressions() const;
+        Partition<TypeExpression, ExprIndex>                type_expressions() const;
+        Partition<NamedDecl, ExprIndex>                     decl_expressions() const;
+        Partition<UnqualifiedId, ExprIndex>                 unqualified_id_expressions() const;
+        Partition<TemplateId, ExprIndex>                    template_ids() const;
+        Partition<TemplateReference, ExprIndex>             template_references() const;
+        Partition<MonadExpression, ExprIndex>               monad_expressions() const;
+        Partition<DyadExpression, ExprIndex>                dyad_expressions() const;
+        Partition<StringExpression, ExprIndex>              string_expressions() const;
+        Partition<CallExpression, ExprIndex>                call_expressions() const;
+        Partition<SizeofExpression, ExprIndex>              sizeof_expressions() const;
+        Partition<AlignofExpression, ExprIndex>             alignof_expressions() const;
+        Partition<RequiresExpression, ExprIndex>            requires_expressions() const;
+        Partition<TupleExpression, ExprIndex>               tuple_expressions() const;
+        Partition<PathExpression, ExprIndex>                path_expressions() const;
+        Partition<ReadExpression, ExprIndex>                read_expressions() const;
+        Partition<SyntaxTreeExpression, ExprIndex>          syntax_tree_expressions() const;
 
-        DECLARE_EXPR_PARTITION_GETTER(LiteralExpression, literal_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(TypeExpression,    type_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(NamedDecl,         decl_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(UnqualifiedId,     unqualified_id_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(TemplateId,        template_ids)
-        DECLARE_EXPR_PARTITION_GETTER(TemplateReference, template_references)
-        DECLARE_EXPR_PARTITION_GETTER(MonadExpression,   monad_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(DyadExpression,    dyad_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(StringExpression,  string_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(CallExpression,    call_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(SizeofExpression,  sizeof_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(AlignofExpression, alignof_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(RequiresExpression,requires_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(TupleExpression,   tuple_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(PathExpression,    path_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(ReadExpression,    read_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(SyntaxTreeExpression, syntax_tree_expressions)
+        Partition<ExpressionListExpression, ExprIndex>      expression_lists() const;
+        Partition<QualifiedNameExpression, ExprIndex>       qualified_name_expressions() const;
+        Partition<PackedTemplateArguments, ExprIndex>       packed_template_arguments() const;
+        Partition<ProductValueTypeExpression, ExprIndex>    product_value_type_expressions() const;
 
-        DECLARE_EXPR_PARTITION_GETTER(ExpressionListExpression,expression_lists)
-        DECLARE_EXPR_PARTITION_GETTER(QualifiedNameExpression, qualified_name_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(PackedTemplateArguments, packed_template_arguments)
-        DECLARE_EXPR_PARTITION_GETTER(ProductValueTypeExpression, product_value_type_expressions)
-
-        DECLARE_UNTYPED_PARTITION_GETTER(StringLiteral, StringIndex, string_literal_expressions)
-
-#undef DECLARE_EXPR_PARTITION_GETTER
+        Partition<StringLiteral, StringIndex> string_literal_expressions() const;
 
         // Heaps
-        DECLARE_UNTYPED_PARTITION_GETTER(TypeIndex, Index, type_heap)
-        DECLARE_UNTYPED_PARTITION_GETTER(ExprIndex, Index, expr_heap)
-        DECLARE_UNTYPED_PARTITION_GETTER(AttrIndex, Index, attr_heap)
-        DECLARE_UNTYPED_PARTITION_GETTER(SyntaxIndex, Index, syntax_heap)
+        Partition<TypeIndex, Index>     type_heap() const;
+        Partition<ExprIndex, Index>     expr_heap() const;
+        Partition<AttrIndex, Index>     attr_heap() const;
+        Partition<SyntaxIndex, Index>   syntax_heap() const;
 
         // Names
-        DECLARE_PARTITION_GETTER(OperatorFunctionName, NameIndex, operator_names)
-        DECLARE_PARTITION_GETTER(SpecializationName,   NameIndex, specialization_names)
-        DECLARE_PARTITION_GETTER(LiteralName,          NameIndex, literal_names)
+        Partition<OperatorFunctionName, NameIndex>  operator_names() const;
+        Partition<SpecializationName, NameIndex>    specialization_names() const;
+        Partition<LiteralName, NameIndex>           literal_names() const;
 
         // Charts
-        DECLARE_PARTITION_GETTER(ChartUnilevel,     ChartIndex, unilevel_charts)
-        DECLARE_PARTITION_GETTER(ChartMultilevel,   ChartIndex, multilevel_charts)
+        Partition<ChartUnilevel, ChartIndex>    unilevel_charts() const;
+        Partition<ChartMultilevel, ChartIndex>  multilevel_charts() const;
 
         // Literals
-        DECLARE_PARTITION_GETTER(IntegerLiteral,    LitIndex,   integer_literals)
-        DECLARE_PARTITION_GETTER(FPLiteral,         LitIndex,   fp_literals)
+        Partition<IntegerLiteral, LitIndex> integer_literals() const;
+        Partition<FPLiteral, LitIndex>      fp_literals() const;
 
         // Syntax Trees
-#define DECLARE_SYNTAX_PARTITION_GETTER(SyntaxType, SyntaxName) \
-    DECLARE_PARTITION_GETTER(SyntaxType, SyntaxIndex, SyntaxName)
-
-        DECLARE_SYNTAX_PARTITION_GETTER(SimpleTypeSpecifier,        simple_type_specifiers)
-        DECLARE_SYNTAX_PARTITION_GETTER(DecltypeSpecifier,          decltype_specifiers)
-        DECLARE_SYNTAX_PARTITION_GETTER(TypeSpecifierSeq,           type_specifier_seq_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(DeclSpecifierSeq,           decl_specifier_seq_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(TypeIdSyntax,               typeid_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(DeclaratorSyntax,           declarator_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(PointerDeclaratorSyntax,    pointer_declarator_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(FunctionDeclaratorSyntax,   function_declarator_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(ParameterDeclaratorSyntax,  parameter_declarator_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(ExpressionSyntax,           expression_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(RequiresClauseSyntax,       requires_clause_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(SimpleRequirementSyntax,    simple_requirement_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(TypeRequirementSyntax,      type_requirement_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(NestedRequirementSyntax,    nested_requirement_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(CompoundRequirementSyntax,  compound_requirement_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(RequirementBodySyntax,      requirement_body_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(TypeTemplateArgumentSyntax, type_template_argument_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(TemplateArgumentListSyntax, template_argument_list_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(TemplateIdSyntax,           templateid_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(TypeTraitIntrinsicSyntax,   type_trait_intrinsic_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(TupleSyntax,                tuple_syntax_trees)
-
-#undef DECLARE_SYNTAX_PARTITION_GETTER
+        Partition<SimpleTypeSpecifier, SyntaxIndex>        simple_type_specifiers() const;
+        Partition<DecltypeSpecifier, SyntaxIndex>          decltype_specifiers() const;
+        Partition<TypeSpecifierSeq, SyntaxIndex>           type_specifier_seq_syntax_trees() const;
+        Partition<DeclSpecifierSeq, SyntaxIndex>           decl_specifier_seq_syntax_trees() const;
+        Partition<TypeIdSyntax, SyntaxIndex>               typeid_syntax_trees() const;
+        Partition<DeclaratorSyntax, SyntaxIndex>           declarator_syntax_trees() const;
+        Partition<PointerDeclaratorSyntax, SyntaxIndex>    pointer_declarator_syntax_trees() const;
+        Partition<FunctionDeclaratorSyntax, SyntaxIndex>   function_declarator_syntax_trees() const;
+        Partition<ParameterDeclaratorSyntax, SyntaxIndex>  parameter_declarator_syntax_trees() const;
+        Partition<ExpressionSyntax, SyntaxIndex>           expression_syntax_trees() const;
+        Partition<RequiresClauseSyntax, SyntaxIndex>       requires_clause_syntax_trees() const;
+        Partition<SimpleRequirementSyntax, SyntaxIndex>    simple_requirement_syntax_trees() const;
+        Partition<TypeRequirementSyntax, SyntaxIndex>      type_requirement_syntax_trees() const;
+        Partition<NestedRequirementSyntax, SyntaxIndex>    nested_requirement_syntax_trees() const;
+        Partition<CompoundRequirementSyntax, SyntaxIndex>  compound_requirement_syntax_trees() const;
+        Partition<RequirementBodySyntax, SyntaxIndex>      requirement_body_syntax_trees() const;
+        Partition<TypeTemplateArgumentSyntax, SyntaxIndex> type_template_argument_syntax_trees() const;
+        Partition<TemplateArgumentListSyntax, SyntaxIndex> template_argument_list_syntax_trees() const;
+        Partition<TemplateIdSyntax, SyntaxIndex>           templateid_syntax_trees() const;
+        Partition<TypeTraitIntrinsicSyntax, SyntaxIndex>   type_trait_intrinsic_syntax_trees() const;
+        Partition<TupleSyntax, SyntaxIndex>                tuple_syntax_trees() const;
 
         // Module References
-        DECLARE_UNTYPED_PARTITION_GETTER(ModuleReference, Index, imported_modules);
-        DECLARE_UNTYPED_PARTITION_GETTER(ModuleReference, Index, exported_modules);
+        Partition<ModuleReference, Index> imported_modules() const;
+        Partition<ModuleReference, Index> exported_modules() const;
 
         Partition<DeclIndex> deduction_guides() const;
-
-#undef DECLARE_PARTITION_GETTER
-#undef DECLARE_UNTYPED_PARTITION_GETTER
 
     public:
         // Traits
@@ -218,13 +178,6 @@ namespace ifc
 
         File           (File &&) noexcept;
         File& operator=(File &&) noexcept;
-
-    private:
-        template<typename T, typename Index>
-        Partition<T, Index> get_partition_with_cache(std::optional<Partition<T, Index>> & cache) const;
-
-        template<typename T, typename Index>
-        Partition<T, Index> get_partition_with_cache(std::optional<Partition<T, Index>> & cache, std::string_view) const;
 
     private:
         struct Impl;

--- a/lib/core/include/ifc/File.h
+++ b/lib/core/include/ifc/File.h
@@ -34,175 +34,144 @@ namespace ifc
 
         std::byte const* get_data_pointer(PartitionSummary const&) const;
 
-#define DECLARE_UNTYPED_PARTITION_GETTER(ElementType, IndexType, Property)  \
-    public:                                                                 \
-    Partition<ElementType, IndexType> Property() const;                     \
-    private:                                                                \
-        mutable std::optional<Partition<ElementType, IndexType>> cached_ ## Property ## _ ;
-
 #define DECLARE_PARTITION_GETTER(ElementType, IndexType, Property)  \
     public:                                                         \
-    TypedPartition<ElementType, IndexType> Property() const;        \
+    Partition<ElementType, IndexType> Property() const;        \
     private:                                                        \
         mutable std::optional<Partition<ElementType, IndexType>> cached_ ## Property ## _ ;
 
-        // Declarations
-        DECLARE_UNTYPED_PARTITION_GETTER(Declaration, Index, declarations)
+    // Declarations
+    DECLARE_PARTITION_GETTER(Declaration, Index, declarations)
 
-#define DECLARE_DECL_PARTITION_GETTER(DeclType, DeclName) \
-    DECLARE_PARTITION_GETTER(DeclType, DeclIndex, DeclName)
+    DECLARE_PARTITION_GETTER(ScopeDeclaration, DeclIndex, scope_declarations)
+    DECLARE_PARTITION_GETTER(TemplateDeclaration, DeclIndex, template_declarations)
+    DECLARE_PARTITION_GETTER(PartialSpecialization, DeclIndex, partial_specializations)
+    DECLARE_PARTITION_GETTER(Specialization, DeclIndex, specializations)
+    DECLARE_PARTITION_GETTER(UsingDeclaration, DeclIndex, using_declarations)
+    DECLARE_PARTITION_GETTER(Enumeration, DeclIndex, enumerations)
+    DECLARE_PARTITION_GETTER(Enumerator, DeclIndex, enumerators)
+    DECLARE_PARTITION_GETTER(AliasDeclaration, DeclIndex, alias_declarations)
+    DECLARE_PARTITION_GETTER(DeclReference, DeclIndex, decl_references)
+    DECLARE_PARTITION_GETTER(FunctionDeclaration, DeclIndex, functions)
+    DECLARE_PARTITION_GETTER(MethodDeclaration, DeclIndex, methods)
+    DECLARE_PARTITION_GETTER(Constructor, DeclIndex, constructors)
+    DECLARE_PARTITION_GETTER(Destructor, DeclIndex, destructors)
+    DECLARE_PARTITION_GETTER(VariableDeclaration, DeclIndex, variables)
+    DECLARE_PARTITION_GETTER(ParameterDeclaration, DeclIndex, parameters)
+    DECLARE_PARTITION_GETTER(FieldDeclaration, DeclIndex, fields)
+    DECLARE_PARTITION_GETTER(FriendDeclaration, DeclIndex, friends)
+    DECLARE_PARTITION_GETTER(Concept, DeclIndex, concepts)
+    DECLARE_PARTITION_GETTER(IntrinsicDeclaration, DeclIndex,  intrinsic_declarations)
 
-        DECLARE_DECL_PARTITION_GETTER(ScopeDeclaration,      scope_declarations)
-        DECLARE_DECL_PARTITION_GETTER(TemplateDeclaration,   template_declarations)
-        DECLARE_DECL_PARTITION_GETTER(PartialSpecialization, partial_specializations)
-        DECLARE_DECL_PARTITION_GETTER(Specialization,        specializations)
-        DECLARE_DECL_PARTITION_GETTER(UsingDeclaration,      using_declarations)
-        DECLARE_DECL_PARTITION_GETTER(Enumeration,           enumerations)
-        DECLARE_DECL_PARTITION_GETTER(Enumerator,            enumerators)
-        DECLARE_DECL_PARTITION_GETTER(AliasDeclaration,      alias_declarations)
-        DECLARE_DECL_PARTITION_GETTER(DeclReference,         decl_references)
-        DECLARE_DECL_PARTITION_GETTER(FunctionDeclaration,   functions)
-        DECLARE_DECL_PARTITION_GETTER(MethodDeclaration,     methods)
-        DECLARE_DECL_PARTITION_GETTER(Constructor,           constructors)
-        DECLARE_DECL_PARTITION_GETTER(Destructor,            destructors)
-        DECLARE_DECL_PARTITION_GETTER(VariableDeclaration,   variables)
-        DECLARE_DECL_PARTITION_GETTER(ParameterDeclaration,  parameters)
-        DECLARE_DECL_PARTITION_GETTER(FieldDeclaration,      fields)
-        DECLARE_DECL_PARTITION_GETTER(FriendDeclaration,     friends)
-        DECLARE_DECL_PARTITION_GETTER(Concept,               concepts)
-        DECLARE_DECL_PARTITION_GETTER(IntrinsicDeclaration,  intrinsic_declarations)
+    DECLARE_PARTITION_GETTER(SpecializationForm, SpecFormIndex, specialization_forms)
 
-#undef DECLARE_DECL_PARTITION_GETTER
+    // Types
+    DECLARE_PARTITION_GETTER(FundamentalType, TypeIndex, fundamental_types)
+    DECLARE_PARTITION_GETTER(DesignatedType, TypeIndex, designated_types)
+    DECLARE_PARTITION_GETTER(TorType, TypeIndex, tor_types)
+    DECLARE_PARTITION_GETTER(SyntacticType, TypeIndex, syntactic_types)
+    DECLARE_PARTITION_GETTER(ExpansionType, TypeIndex, expansion_types)
+    DECLARE_PARTITION_GETTER(PointerType, TypeIndex, pointer_types)
+    DECLARE_PARTITION_GETTER(FunctionType, TypeIndex, function_types)
+    DECLARE_PARTITION_GETTER(MethodType, TypeIndex, method_types)
+    DECLARE_PARTITION_GETTER(ArrayType, TypeIndex, array_types)
+    DECLARE_PARTITION_GETTER(BaseType, TypeIndex, base_types)
+    DECLARE_PARTITION_GETTER(TupleType, TypeIndex, tuple_types)
+    DECLARE_PARTITION_GETTER(LvalueReference, TypeIndex, lvalue_references)
+    DECLARE_PARTITION_GETTER(RvalueReference, TypeIndex, rvalue_references)
+    DECLARE_PARTITION_GETTER(QualifiedType, TypeIndex, qualified_types)
+    DECLARE_PARTITION_GETTER(ForallType, TypeIndex, forall_types)
+    DECLARE_PARTITION_GETTER(SyntaxType, TypeIndex, syntax_types)
+    DECLARE_PARTITION_GETTER(PlaceholderType, TypeIndex, placeholder_types)
+    DECLARE_PARTITION_GETTER(TypenameType, TypeIndex, typename_types)
+    DECLARE_PARTITION_GETTER(DecltypeType, TypeIndex, decltype_types)
 
-        DECLARE_UNTYPED_PARTITION_GETTER(SpecializationForm, SpecFormIndex, specialization_forms)
+    // Attributes
+    DECLARE_PARTITION_GETTER(AttrBasic, AttrIndex, basic_attributes)
+    DECLARE_PARTITION_GETTER(AttrScoped, AttrIndex, scoped_attributes)
+    DECLARE_PARTITION_GETTER(AttrLabeled, AttrIndex, labeled_attributes)
+    DECLARE_PARTITION_GETTER(AttrCalled, AttrIndex, called_attributes)
+    DECLARE_PARTITION_GETTER(AttrExpanded, AttrIndex, expanded_attributes)
+    DECLARE_PARTITION_GETTER(AttrFactored, AttrIndex, factored_attributes)
+    DECLARE_PARTITION_GETTER(AttrElaborated, AttrIndex, elaborated_attributes)
+    DECLARE_PARTITION_GETTER(AttrTuple, AttrIndex, tuple_attributes)
 
-        // Types
-#define DECLARE_TYPE_PARTITION_GETTER(Type, TypeName) \
-    DECLARE_PARTITION_GETTER(Type, TypeIndex, TypeName)
+    // Expressions
+    DECLARE_PARTITION_GETTER(LiteralExpression, ExprIndex, literal_expressions)
+    DECLARE_PARTITION_GETTER(TypeExpression, ExprIndex, type_expressions)
+    DECLARE_PARTITION_GETTER(NamedDecl, ExprIndex, decl_expressions)
+    DECLARE_PARTITION_GETTER(UnqualifiedId, ExprIndex, unqualified_id_expressions)
+    DECLARE_PARTITION_GETTER(TemplateId, ExprIndex, template_ids)
+    DECLARE_PARTITION_GETTER(TemplateReference, ExprIndex, template_references)
+    DECLARE_PARTITION_GETTER(MonadExpression, ExprIndex, monad_expressions)
+    DECLARE_PARTITION_GETTER(DyadExpression, ExprIndex, dyad_expressions)
+    DECLARE_PARTITION_GETTER(StringExpression, ExprIndex, string_expressions)
+    DECLARE_PARTITION_GETTER(CallExpression, ExprIndex, call_expressions)
+    DECLARE_PARTITION_GETTER(SizeofExpression, ExprIndex, sizeof_expressions)
+    DECLARE_PARTITION_GETTER(AlignofExpression, ExprIndex, alignof_expressions)
+    DECLARE_PARTITION_GETTER(RequiresExpression, ExprIndex, requires_expressions)
+    DECLARE_PARTITION_GETTER(TupleExpression, ExprIndex, tuple_expressions)
+    DECLARE_PARTITION_GETTER(PathExpression, ExprIndex, path_expressions)
+    DECLARE_PARTITION_GETTER(ReadExpression, ExprIndex, read_expressions)
+    DECLARE_PARTITION_GETTER(SyntaxTreeExpression, ExprIndex, syntax_tree_expressions)
 
-        DECLARE_TYPE_PARTITION_GETTER(FundamentalType,    fundamental_types)
-        DECLARE_TYPE_PARTITION_GETTER(DesignatedType,     designated_types)
-        DECLARE_TYPE_PARTITION_GETTER(TorType,            tor_types)
-        DECLARE_TYPE_PARTITION_GETTER(SyntacticType,      syntactic_types)
-        DECLARE_TYPE_PARTITION_GETTER(ExpansionType,      expansion_types)
-        DECLARE_TYPE_PARTITION_GETTER(PointerType,        pointer_types)
-        DECLARE_TYPE_PARTITION_GETTER(FunctionType,       function_types)
-        DECLARE_TYPE_PARTITION_GETTER(MethodType,         method_types)
-        DECLARE_TYPE_PARTITION_GETTER(ArrayType,          array_types)
-        DECLARE_TYPE_PARTITION_GETTER(BaseType,           base_types)
-        DECLARE_TYPE_PARTITION_GETTER(TupleType,          tuple_types)
-        DECLARE_TYPE_PARTITION_GETTER(LvalueReference,    lvalue_references)
-        DECLARE_TYPE_PARTITION_GETTER(RvalueReference,    rvalue_references)
-        DECLARE_TYPE_PARTITION_GETTER(QualifiedType,      qualified_types)
-        DECLARE_TYPE_PARTITION_GETTER(ForallType,         forall_types)
-        DECLARE_TYPE_PARTITION_GETTER(SyntaxType,         syntax_types)
-        DECLARE_TYPE_PARTITION_GETTER(PlaceholderType,    placeholder_types)
-        DECLARE_TYPE_PARTITION_GETTER(TypenameType,       typename_types)
-        DECLARE_TYPE_PARTITION_GETTER(DecltypeType,       decltype_types)
+    DECLARE_PARTITION_GETTER(ExpressionListExpression, ExprIndex, expression_lists)
+    DECLARE_PARTITION_GETTER(QualifiedNameExpression, ExprIndex, qualified_name_expressions)
+    DECLARE_PARTITION_GETTER(PackedTemplateArguments, ExprIndex, packed_template_arguments)
+    DECLARE_PARTITION_GETTER(ProductValueTypeExpression, ExprIndex, product_value_type_expressions)
 
-#undef DECLARE_TYPE_PARTITION_GETTER
+    DECLARE_PARTITION_GETTER(StringLiteral, StringIndex, string_literal_expressions)
 
-        // Attributes
-#define DECLARE_ATTR_PARTITION_GETTER(ExprType, ExprName) \
-    DECLARE_PARTITION_GETTER(ExprType, AttrIndex, ExprName)
+    // Heaps
+    DECLARE_PARTITION_GETTER(TypeIndex, Index, type_heap)
+    DECLARE_PARTITION_GETTER(ExprIndex, Index, expr_heap)
+    DECLARE_PARTITION_GETTER(AttrIndex, Index, attr_heap)
+    DECLARE_PARTITION_GETTER(SyntaxIndex, Index, syntax_heap)
 
-        DECLARE_ATTR_PARTITION_GETTER(AttrBasic, basic_attributes)
-        DECLARE_ATTR_PARTITION_GETTER(AttrScoped, scoped_attributes)
-        DECLARE_ATTR_PARTITION_GETTER(AttrLabeled, labeled_attributes)
-        DECLARE_ATTR_PARTITION_GETTER(AttrCalled, called_attributes)
-        DECLARE_ATTR_PARTITION_GETTER(AttrExpanded, expanded_attributes)
-        DECLARE_ATTR_PARTITION_GETTER(AttrFactored, factored_attributes)
-        DECLARE_ATTR_PARTITION_GETTER(AttrElaborated, elaborated_attributes)
-        DECLARE_ATTR_PARTITION_GETTER(AttrTuple, tuple_attributes)
+    // Names
+    DECLARE_PARTITION_GETTER(OperatorFunctionName, NameIndex, operator_names)
+    DECLARE_PARTITION_GETTER(SpecializationName,   NameIndex, specialization_names)
+    DECLARE_PARTITION_GETTER(LiteralName,          NameIndex, literal_names)
 
-#undef DECLARE_ATTR_PARTITION_GETTER
+    // Charts
+    DECLARE_PARTITION_GETTER(ChartUnilevel,     ChartIndex, unilevel_charts)
+    DECLARE_PARTITION_GETTER(ChartMultilevel,   ChartIndex, multilevel_charts)
 
-        // Expressions
-#define DECLARE_EXPR_PARTITION_GETTER(ExprType, ExprName) \
-    DECLARE_PARTITION_GETTER(ExprType, ExprIndex, ExprName)
+    // Literals
+    DECLARE_PARTITION_GETTER(IntegerLiteral,    LitIndex,   integer_literals)
+    DECLARE_PARTITION_GETTER(FPLiteral,         LitIndex,   fp_literals)
 
-        DECLARE_EXPR_PARTITION_GETTER(LiteralExpression, literal_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(TypeExpression,    type_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(NamedDecl,         decl_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(UnqualifiedId,     unqualified_id_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(TemplateId,        template_ids)
-        DECLARE_EXPR_PARTITION_GETTER(TemplateReference, template_references)
-        DECLARE_EXPR_PARTITION_GETTER(MonadExpression,   monad_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(DyadExpression,    dyad_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(StringExpression,  string_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(CallExpression,    call_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(SizeofExpression,  sizeof_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(AlignofExpression, alignof_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(RequiresExpression,requires_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(TupleExpression,   tuple_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(PathExpression,    path_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(ReadExpression,    read_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(SyntaxTreeExpression, syntax_tree_expressions)
+    // Syntax Trees
+    DECLARE_PARTITION_GETTER(SimpleTypeSpecifier, SyntaxIndex, simple_type_specifiers)
+    DECLARE_PARTITION_GETTER(DecltypeSpecifier, SyntaxIndex, decltype_specifiers)
+    DECLARE_PARTITION_GETTER(TypeSpecifierSeq, SyntaxIndex, type_specifier_seq_syntax_trees)
+    DECLARE_PARTITION_GETTER(DeclSpecifierSeq, SyntaxIndex, decl_specifier_seq_syntax_trees)
+    DECLARE_PARTITION_GETTER(TypeIdSyntax, SyntaxIndex, typeid_syntax_trees)
+    DECLARE_PARTITION_GETTER(DeclaratorSyntax, SyntaxIndex, declarator_syntax_trees)
+    DECLARE_PARTITION_GETTER(PointerDeclaratorSyntax, SyntaxIndex, pointer_declarator_syntax_trees)
+    DECLARE_PARTITION_GETTER(FunctionDeclaratorSyntax, SyntaxIndex, function_declarator_syntax_trees)
+    DECLARE_PARTITION_GETTER(ParameterDeclaratorSyntax, SyntaxIndex, parameter_declarator_syntax_trees)
+    DECLARE_PARTITION_GETTER(ExpressionSyntax, SyntaxIndex, expression_syntax_trees)
+    DECLARE_PARTITION_GETTER(RequiresClauseSyntax, SyntaxIndex, requires_clause_syntax_trees)
+    DECLARE_PARTITION_GETTER(SimpleRequirementSyntax, SyntaxIndex, simple_requirement_syntax_trees)
+    DECLARE_PARTITION_GETTER(TypeRequirementSyntax, SyntaxIndex, type_requirement_syntax_trees)
+    DECLARE_PARTITION_GETTER(NestedRequirementSyntax, SyntaxIndex, nested_requirement_syntax_trees)
+    DECLARE_PARTITION_GETTER(CompoundRequirementSyntax, SyntaxIndex, compound_requirement_syntax_trees)
+    DECLARE_PARTITION_GETTER(RequirementBodySyntax, SyntaxIndex, requirement_body_syntax_trees)
+    DECLARE_PARTITION_GETTER(TypeTemplateArgumentSyntax, SyntaxIndex, type_template_argument_syntax_trees)
+    DECLARE_PARTITION_GETTER(TemplateArgumentListSyntax, SyntaxIndex, template_argument_list_syntax_trees)
+    DECLARE_PARTITION_GETTER(TemplateIdSyntax, SyntaxIndex, templateid_syntax_trees)
+    DECLARE_PARTITION_GETTER(TypeTraitIntrinsicSyntax, SyntaxIndex, type_trait_intrinsic_syntax_trees)
+    DECLARE_PARTITION_GETTER(TupleSyntax, SyntaxIndex, tuple_syntax_trees)
 
-        DECLARE_EXPR_PARTITION_GETTER(ExpressionListExpression,expression_lists)
-        DECLARE_EXPR_PARTITION_GETTER(QualifiedNameExpression, qualified_name_expressions)
-        DECLARE_EXPR_PARTITION_GETTER(PackedTemplateArguments, packed_template_arguments)
-        DECLARE_EXPR_PARTITION_GETTER(ProductValueTypeExpression, product_value_type_expressions)
+    // Module References
+    DECLARE_PARTITION_GETTER(ModuleReference, Index, imported_modules);
+    DECLARE_PARTITION_GETTER(ModuleReference, Index, exported_modules);
 
-        DECLARE_UNTYPED_PARTITION_GETTER(StringLiteral, StringIndex, string_literal_expressions)
-
-#undef DECLARE_EXPR_PARTITION_GETTER
-
-        // Heaps
-        DECLARE_UNTYPED_PARTITION_GETTER(TypeIndex, Index, type_heap)
-        DECLARE_UNTYPED_PARTITION_GETTER(ExprIndex, Index, expr_heap)
-        DECLARE_UNTYPED_PARTITION_GETTER(AttrIndex, Index, attr_heap)
-        DECLARE_UNTYPED_PARTITION_GETTER(SyntaxIndex, Index, syntax_heap)
-
-        // Names
-        DECLARE_PARTITION_GETTER(OperatorFunctionName, NameIndex, operator_names)
-        DECLARE_PARTITION_GETTER(SpecializationName,   NameIndex, specialization_names)
-        DECLARE_PARTITION_GETTER(LiteralName,          NameIndex, literal_names)
-
-        // Charts
-        DECLARE_PARTITION_GETTER(ChartUnilevel,     ChartIndex, unilevel_charts)
-        DECLARE_PARTITION_GETTER(ChartMultilevel,   ChartIndex, multilevel_charts)
-
-        // Literals
-        DECLARE_PARTITION_GETTER(IntegerLiteral,    LitIndex,   integer_literals)
-        DECLARE_PARTITION_GETTER(FPLiteral,         LitIndex,   fp_literals)
-
-        // Syntax Trees
-#define DECLARE_SYNTAX_PARTITION_GETTER(SyntaxType, SyntaxName) \
-    DECLARE_PARTITION_GETTER(SyntaxType, SyntaxIndex, SyntaxName)
-
-        DECLARE_SYNTAX_PARTITION_GETTER(SimpleTypeSpecifier,        simple_type_specifiers)
-        DECLARE_SYNTAX_PARTITION_GETTER(DecltypeSpecifier,          decltype_specifiers)
-        DECLARE_SYNTAX_PARTITION_GETTER(TypeSpecifierSeq,           type_specifier_seq_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(DeclSpecifierSeq,           decl_specifier_seq_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(TypeIdSyntax,               typeid_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(DeclaratorSyntax,           declarator_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(PointerDeclaratorSyntax,    pointer_declarator_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(FunctionDeclaratorSyntax,   function_declarator_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(ParameterDeclaratorSyntax,  parameter_declarator_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(ExpressionSyntax,           expression_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(RequiresClauseSyntax,       requires_clause_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(SimpleRequirementSyntax,    simple_requirement_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(TypeRequirementSyntax,      type_requirement_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(NestedRequirementSyntax,    nested_requirement_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(CompoundRequirementSyntax,  compound_requirement_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(RequirementBodySyntax,      requirement_body_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(TypeTemplateArgumentSyntax, type_template_argument_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(TemplateArgumentListSyntax, template_argument_list_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(TemplateIdSyntax,           templateid_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(TypeTraitIntrinsicSyntax,   type_trait_intrinsic_syntax_trees)
-        DECLARE_SYNTAX_PARTITION_GETTER(TupleSyntax,                tuple_syntax_trees)
-
-#undef DECLARE_SYNTAX_PARTITION_GETTER
-
-        // Module References
-        DECLARE_UNTYPED_PARTITION_GETTER(ModuleReference, Index, imported_modules);
-        DECLARE_UNTYPED_PARTITION_GETTER(ModuleReference, Index, exported_modules);
-
-        Partition<DeclIndex> deduction_guides() const;
+    // Deducation guides
+    Partition<DeclIndex> deduction_guides() const;
 
 #undef DECLARE_PARTITION_GETTER
-#undef DECLARE_UNTYPED_PARTITION_GETTER
 
     public:
         // Traits

--- a/lib/core/include/ifc/File.h
+++ b/lib/core/include/ifc/File.h
@@ -34,135 +34,175 @@ namespace ifc
 
         std::byte const* get_data_pointer(PartitionSummary const&) const;
 
+#define DECLARE_UNTYPED_PARTITION_GETTER(ElementType, IndexType, Property)  \
+    public:                                                                 \
+    Partition<ElementType, IndexType> Property() const;                     \
+    private:                                                                \
+        mutable std::optional<Partition<ElementType, IndexType>> cached_ ## Property ## _ ;
+
+#define DECLARE_PARTITION_GETTER(ElementType, IndexType, Property)  \
+    public:                                                         \
+    TypedPartition<ElementType, IndexType> Property() const;        \
+    private:                                                        \
+        mutable std::optional<Partition<ElementType, IndexType>> cached_ ## Property ## _ ;
+
         // Declarations
-        Partition<Declaration, Index>               declarations() const;
+        DECLARE_UNTYPED_PARTITION_GETTER(Declaration, Index, declarations)
 
-        Partition<ScopeDeclaration, DeclIndex>      scope_declarations() const;
-        Partition<TemplateDeclaration, DeclIndex>   template_declarations() const;
-        Partition<PartialSpecialization, DeclIndex> partial_specializations() const;
-        Partition<Specialization, DeclIndex>        specializations() const;
-        Partition<UsingDeclaration, DeclIndex>      using_declarations() const;
-        Partition<Enumeration, DeclIndex>           enumerations() const;
-        Partition<Enumerator, DeclIndex>            enumerators() const;
-        Partition<AliasDeclaration, DeclIndex>      alias_declarations() const;
-        Partition<DeclReference, DeclIndex>         decl_references() const;
-        Partition<FunctionDeclaration, DeclIndex>   functions() const;
-        Partition<MethodDeclaration, DeclIndex>     methods() const;
-        Partition<Constructor, DeclIndex>           constructors() const;
-        Partition<Destructor, DeclIndex>            destructors() const;
-        Partition<VariableDeclaration, DeclIndex>   variables() const;
-        Partition<ParameterDeclaration, DeclIndex>  parameters() const;
-        Partition<FieldDeclaration, DeclIndex>      fields() const;
-        Partition<FriendDeclaration, DeclIndex>     friends() const;
-        Partition<Concept, DeclIndex>               concepts() const;
-        Partition<IntrinsicDeclaration, DeclIndex>  intrinsic_declarations() const;
+#define DECLARE_DECL_PARTITION_GETTER(DeclType, DeclName) \
+    DECLARE_PARTITION_GETTER(DeclType, DeclIndex, DeclName)
 
-        Partition<SpecializationForm, SpecFormIndex> specialization_forms() const;
+        DECLARE_DECL_PARTITION_GETTER(ScopeDeclaration,      scope_declarations)
+        DECLARE_DECL_PARTITION_GETTER(TemplateDeclaration,   template_declarations)
+        DECLARE_DECL_PARTITION_GETTER(PartialSpecialization, partial_specializations)
+        DECLARE_DECL_PARTITION_GETTER(Specialization,        specializations)
+        DECLARE_DECL_PARTITION_GETTER(UsingDeclaration,      using_declarations)
+        DECLARE_DECL_PARTITION_GETTER(Enumeration,           enumerations)
+        DECLARE_DECL_PARTITION_GETTER(Enumerator,            enumerators)
+        DECLARE_DECL_PARTITION_GETTER(AliasDeclaration,      alias_declarations)
+        DECLARE_DECL_PARTITION_GETTER(DeclReference,         decl_references)
+        DECLARE_DECL_PARTITION_GETTER(FunctionDeclaration,   functions)
+        DECLARE_DECL_PARTITION_GETTER(MethodDeclaration,     methods)
+        DECLARE_DECL_PARTITION_GETTER(Constructor,           constructors)
+        DECLARE_DECL_PARTITION_GETTER(Destructor,            destructors)
+        DECLARE_DECL_PARTITION_GETTER(VariableDeclaration,   variables)
+        DECLARE_DECL_PARTITION_GETTER(ParameterDeclaration,  parameters)
+        DECLARE_DECL_PARTITION_GETTER(FieldDeclaration,      fields)
+        DECLARE_DECL_PARTITION_GETTER(FriendDeclaration,     friends)
+        DECLARE_DECL_PARTITION_GETTER(Concept,               concepts)
+        DECLARE_DECL_PARTITION_GETTER(IntrinsicDeclaration,  intrinsic_declarations)
+
+#undef DECLARE_DECL_PARTITION_GETTER
+
+        DECLARE_UNTYPED_PARTITION_GETTER(SpecializationForm, SpecFormIndex, specialization_forms)
 
         // Types
-        Partition<FundamentalType, TypeIndex>    fundamental_types() const;
-        Partition<DesignatedType, TypeIndex>     designated_types() const;
-        Partition<TorType, TypeIndex>            tor_types() const;
-        Partition<SyntacticType, TypeIndex>      syntactic_types() const;
-        Partition<ExpansionType, TypeIndex>      expansion_types() const;
-        Partition<PointerType, TypeIndex>        pointer_types() const;
-        Partition<FunctionType, TypeIndex>       function_types() const;
-        Partition<MethodType, TypeIndex>         method_types() const;
-        Partition<ArrayType, TypeIndex>          array_types() const;
-        Partition<BaseType, TypeIndex>           base_types() const;
-        Partition<TupleType, TypeIndex>          tuple_types() const;
-        Partition<LvalueReference, TypeIndex>    lvalue_references() const;
-        Partition<RvalueReference, TypeIndex>    rvalue_references() const;
-        Partition<QualifiedType, TypeIndex>      qualified_types() const;
-        Partition<ForallType, TypeIndex>         forall_types() const;
-        Partition<SyntaxType, TypeIndex>         syntax_types() const;
-        Partition<PlaceholderType, TypeIndex>    placeholder_types() const;
-        Partition<TypenameType, TypeIndex>       typename_types() const;
-        Partition<DecltypeType, TypeIndex>       decltype_types() const;
+#define DECLARE_TYPE_PARTITION_GETTER(Type, TypeName) \
+    DECLARE_PARTITION_GETTER(Type, TypeIndex, TypeName)
+
+        DECLARE_TYPE_PARTITION_GETTER(FundamentalType,    fundamental_types)
+        DECLARE_TYPE_PARTITION_GETTER(DesignatedType,     designated_types)
+        DECLARE_TYPE_PARTITION_GETTER(TorType,            tor_types)
+        DECLARE_TYPE_PARTITION_GETTER(SyntacticType,      syntactic_types)
+        DECLARE_TYPE_PARTITION_GETTER(ExpansionType,      expansion_types)
+        DECLARE_TYPE_PARTITION_GETTER(PointerType,        pointer_types)
+        DECLARE_TYPE_PARTITION_GETTER(FunctionType,       function_types)
+        DECLARE_TYPE_PARTITION_GETTER(MethodType,         method_types)
+        DECLARE_TYPE_PARTITION_GETTER(ArrayType,          array_types)
+        DECLARE_TYPE_PARTITION_GETTER(BaseType,           base_types)
+        DECLARE_TYPE_PARTITION_GETTER(TupleType,          tuple_types)
+        DECLARE_TYPE_PARTITION_GETTER(LvalueReference,    lvalue_references)
+        DECLARE_TYPE_PARTITION_GETTER(RvalueReference,    rvalue_references)
+        DECLARE_TYPE_PARTITION_GETTER(QualifiedType,      qualified_types)
+        DECLARE_TYPE_PARTITION_GETTER(ForallType,         forall_types)
+        DECLARE_TYPE_PARTITION_GETTER(SyntaxType,         syntax_types)
+        DECLARE_TYPE_PARTITION_GETTER(PlaceholderType,    placeholder_types)
+        DECLARE_TYPE_PARTITION_GETTER(TypenameType,       typename_types)
+        DECLARE_TYPE_PARTITION_GETTER(DecltypeType,       decltype_types)
+
+#undef DECLARE_TYPE_PARTITION_GETTER
 
         // Attributes
-        Partition<AttrBasic, AttrIndex>         basic_attributes() const;
-        Partition<AttrScoped, AttrIndex>        scoped_attributes() const;
-        Partition<AttrLabeled, AttrIndex>       labeled_attributes() const;
-        Partition<AttrCalled, AttrIndex>        called_attributes() const;
-        Partition<AttrExpanded, AttrIndex>      expanded_attributes() const;
-        Partition<AttrFactored, AttrIndex>      factored_attributes() const;
-        Partition<AttrElaborated, AttrIndex>    elaborated_attributes() const;
-        Partition<AttrTuple, AttrIndex>         tuple_attributes() const;
+#define DECLARE_ATTR_PARTITION_GETTER(ExprType, ExprName) \
+    DECLARE_PARTITION_GETTER(ExprType, AttrIndex, ExprName)
+
+        DECLARE_ATTR_PARTITION_GETTER(AttrBasic, basic_attributes)
+        DECLARE_ATTR_PARTITION_GETTER(AttrScoped, scoped_attributes)
+        DECLARE_ATTR_PARTITION_GETTER(AttrLabeled, labeled_attributes)
+        DECLARE_ATTR_PARTITION_GETTER(AttrCalled, called_attributes)
+        DECLARE_ATTR_PARTITION_GETTER(AttrExpanded, expanded_attributes)
+        DECLARE_ATTR_PARTITION_GETTER(AttrFactored, factored_attributes)
+        DECLARE_ATTR_PARTITION_GETTER(AttrElaborated, elaborated_attributes)
+        DECLARE_ATTR_PARTITION_GETTER(AttrTuple, tuple_attributes)
+
+#undef DECLARE_ATTR_PARTITION_GETTER
 
         // Expressions
-        Partition<LiteralExpression, ExprIndex>             literal_expressions() const;
-        Partition<TypeExpression, ExprIndex>                type_expressions() const;
-        Partition<NamedDecl, ExprIndex>                     decl_expressions() const;
-        Partition<UnqualifiedId, ExprIndex>                 unqualified_id_expressions() const;
-        Partition<TemplateId, ExprIndex>                    template_ids() const;
-        Partition<TemplateReference, ExprIndex>             template_references() const;
-        Partition<MonadExpression, ExprIndex>               monad_expressions() const;
-        Partition<DyadExpression, ExprIndex>                dyad_expressions() const;
-        Partition<StringExpression, ExprIndex>              string_expressions() const;
-        Partition<CallExpression, ExprIndex>                call_expressions() const;
-        Partition<SizeofExpression, ExprIndex>              sizeof_expressions() const;
-        Partition<AlignofExpression, ExprIndex>             alignof_expressions() const;
-        Partition<RequiresExpression, ExprIndex>            requires_expressions() const;
-        Partition<TupleExpression, ExprIndex>               tuple_expressions() const;
-        Partition<PathExpression, ExprIndex>                path_expressions() const;
-        Partition<ReadExpression, ExprIndex>                read_expressions() const;
-        Partition<SyntaxTreeExpression, ExprIndex>          syntax_tree_expressions() const;
+#define DECLARE_EXPR_PARTITION_GETTER(ExprType, ExprName) \
+    DECLARE_PARTITION_GETTER(ExprType, ExprIndex, ExprName)
 
-        Partition<ExpressionListExpression, ExprIndex>      expression_lists() const;
-        Partition<QualifiedNameExpression, ExprIndex>       qualified_name_expressions() const;
-        Partition<PackedTemplateArguments, ExprIndex>       packed_template_arguments() const;
-        Partition<ProductValueTypeExpression, ExprIndex>    product_value_type_expressions() const;
+        DECLARE_EXPR_PARTITION_GETTER(LiteralExpression, literal_expressions)
+        DECLARE_EXPR_PARTITION_GETTER(TypeExpression,    type_expressions)
+        DECLARE_EXPR_PARTITION_GETTER(NamedDecl,         decl_expressions)
+        DECLARE_EXPR_PARTITION_GETTER(UnqualifiedId,     unqualified_id_expressions)
+        DECLARE_EXPR_PARTITION_GETTER(TemplateId,        template_ids)
+        DECLARE_EXPR_PARTITION_GETTER(TemplateReference, template_references)
+        DECLARE_EXPR_PARTITION_GETTER(MonadExpression,   monad_expressions)
+        DECLARE_EXPR_PARTITION_GETTER(DyadExpression,    dyad_expressions)
+        DECLARE_EXPR_PARTITION_GETTER(StringExpression,  string_expressions)
+        DECLARE_EXPR_PARTITION_GETTER(CallExpression,    call_expressions)
+        DECLARE_EXPR_PARTITION_GETTER(SizeofExpression,  sizeof_expressions)
+        DECLARE_EXPR_PARTITION_GETTER(AlignofExpression, alignof_expressions)
+        DECLARE_EXPR_PARTITION_GETTER(RequiresExpression,requires_expressions)
+        DECLARE_EXPR_PARTITION_GETTER(TupleExpression,   tuple_expressions)
+        DECLARE_EXPR_PARTITION_GETTER(PathExpression,    path_expressions)
+        DECLARE_EXPR_PARTITION_GETTER(ReadExpression,    read_expressions)
+        DECLARE_EXPR_PARTITION_GETTER(SyntaxTreeExpression, syntax_tree_expressions)
 
-        Partition<StringLiteral, StringIndex> string_literal_expressions() const;
+        DECLARE_EXPR_PARTITION_GETTER(ExpressionListExpression,expression_lists)
+        DECLARE_EXPR_PARTITION_GETTER(QualifiedNameExpression, qualified_name_expressions)
+        DECLARE_EXPR_PARTITION_GETTER(PackedTemplateArguments, packed_template_arguments)
+        DECLARE_EXPR_PARTITION_GETTER(ProductValueTypeExpression, product_value_type_expressions)
+
+        DECLARE_UNTYPED_PARTITION_GETTER(StringLiteral, StringIndex, string_literal_expressions)
+
+#undef DECLARE_EXPR_PARTITION_GETTER
 
         // Heaps
-        Partition<TypeIndex, Index>     type_heap() const;
-        Partition<ExprIndex, Index>     expr_heap() const;
-        Partition<AttrIndex, Index>     attr_heap() const;
-        Partition<SyntaxIndex, Index>   syntax_heap() const;
+        DECLARE_UNTYPED_PARTITION_GETTER(TypeIndex, Index, type_heap)
+        DECLARE_UNTYPED_PARTITION_GETTER(ExprIndex, Index, expr_heap)
+        DECLARE_UNTYPED_PARTITION_GETTER(AttrIndex, Index, attr_heap)
+        DECLARE_UNTYPED_PARTITION_GETTER(SyntaxIndex, Index, syntax_heap)
 
         // Names
-        Partition<OperatorFunctionName, NameIndex>  operator_names() const;
-        Partition<SpecializationName, NameIndex>    specialization_names() const;
-        Partition<LiteralName, NameIndex>           literal_names() const;
+        DECLARE_PARTITION_GETTER(OperatorFunctionName, NameIndex, operator_names)
+        DECLARE_PARTITION_GETTER(SpecializationName,   NameIndex, specialization_names)
+        DECLARE_PARTITION_GETTER(LiteralName,          NameIndex, literal_names)
 
         // Charts
-        Partition<ChartUnilevel, ChartIndex>    unilevel_charts() const;
-        Partition<ChartMultilevel, ChartIndex>  multilevel_charts() const;
+        DECLARE_PARTITION_GETTER(ChartUnilevel,     ChartIndex, unilevel_charts)
+        DECLARE_PARTITION_GETTER(ChartMultilevel,   ChartIndex, multilevel_charts)
 
         // Literals
-        Partition<IntegerLiteral, LitIndex> integer_literals() const;
-        Partition<FPLiteral, LitIndex>      fp_literals() const;
+        DECLARE_PARTITION_GETTER(IntegerLiteral,    LitIndex,   integer_literals)
+        DECLARE_PARTITION_GETTER(FPLiteral,         LitIndex,   fp_literals)
 
         // Syntax Trees
-        Partition<SimpleTypeSpecifier, SyntaxIndex>        simple_type_specifiers() const;
-        Partition<DecltypeSpecifier, SyntaxIndex>          decltype_specifiers() const;
-        Partition<TypeSpecifierSeq, SyntaxIndex>           type_specifier_seq_syntax_trees() const;
-        Partition<DeclSpecifierSeq, SyntaxIndex>           decl_specifier_seq_syntax_trees() const;
-        Partition<TypeIdSyntax, SyntaxIndex>               typeid_syntax_trees() const;
-        Partition<DeclaratorSyntax, SyntaxIndex>           declarator_syntax_trees() const;
-        Partition<PointerDeclaratorSyntax, SyntaxIndex>    pointer_declarator_syntax_trees() const;
-        Partition<FunctionDeclaratorSyntax, SyntaxIndex>   function_declarator_syntax_trees() const;
-        Partition<ParameterDeclaratorSyntax, SyntaxIndex>  parameter_declarator_syntax_trees() const;
-        Partition<ExpressionSyntax, SyntaxIndex>           expression_syntax_trees() const;
-        Partition<RequiresClauseSyntax, SyntaxIndex>       requires_clause_syntax_trees() const;
-        Partition<SimpleRequirementSyntax, SyntaxIndex>    simple_requirement_syntax_trees() const;
-        Partition<TypeRequirementSyntax, SyntaxIndex>      type_requirement_syntax_trees() const;
-        Partition<NestedRequirementSyntax, SyntaxIndex>    nested_requirement_syntax_trees() const;
-        Partition<CompoundRequirementSyntax, SyntaxIndex>  compound_requirement_syntax_trees() const;
-        Partition<RequirementBodySyntax, SyntaxIndex>      requirement_body_syntax_trees() const;
-        Partition<TypeTemplateArgumentSyntax, SyntaxIndex> type_template_argument_syntax_trees() const;
-        Partition<TemplateArgumentListSyntax, SyntaxIndex> template_argument_list_syntax_trees() const;
-        Partition<TemplateIdSyntax, SyntaxIndex>           templateid_syntax_trees() const;
-        Partition<TypeTraitIntrinsicSyntax, SyntaxIndex>   type_trait_intrinsic_syntax_trees() const;
-        Partition<TupleSyntax, SyntaxIndex>                tuple_syntax_trees() const;
+#define DECLARE_SYNTAX_PARTITION_GETTER(SyntaxType, SyntaxName) \
+    DECLARE_PARTITION_GETTER(SyntaxType, SyntaxIndex, SyntaxName)
+
+        DECLARE_SYNTAX_PARTITION_GETTER(SimpleTypeSpecifier,        simple_type_specifiers)
+        DECLARE_SYNTAX_PARTITION_GETTER(DecltypeSpecifier,          decltype_specifiers)
+        DECLARE_SYNTAX_PARTITION_GETTER(TypeSpecifierSeq,           type_specifier_seq_syntax_trees)
+        DECLARE_SYNTAX_PARTITION_GETTER(DeclSpecifierSeq,           decl_specifier_seq_syntax_trees)
+        DECLARE_SYNTAX_PARTITION_GETTER(TypeIdSyntax,               typeid_syntax_trees)
+        DECLARE_SYNTAX_PARTITION_GETTER(DeclaratorSyntax,           declarator_syntax_trees)
+        DECLARE_SYNTAX_PARTITION_GETTER(PointerDeclaratorSyntax,    pointer_declarator_syntax_trees)
+        DECLARE_SYNTAX_PARTITION_GETTER(FunctionDeclaratorSyntax,   function_declarator_syntax_trees)
+        DECLARE_SYNTAX_PARTITION_GETTER(ParameterDeclaratorSyntax,  parameter_declarator_syntax_trees)
+        DECLARE_SYNTAX_PARTITION_GETTER(ExpressionSyntax,           expression_syntax_trees)
+        DECLARE_SYNTAX_PARTITION_GETTER(RequiresClauseSyntax,       requires_clause_syntax_trees)
+        DECLARE_SYNTAX_PARTITION_GETTER(SimpleRequirementSyntax,    simple_requirement_syntax_trees)
+        DECLARE_SYNTAX_PARTITION_GETTER(TypeRequirementSyntax,      type_requirement_syntax_trees)
+        DECLARE_SYNTAX_PARTITION_GETTER(NestedRequirementSyntax,    nested_requirement_syntax_trees)
+        DECLARE_SYNTAX_PARTITION_GETTER(CompoundRequirementSyntax,  compound_requirement_syntax_trees)
+        DECLARE_SYNTAX_PARTITION_GETTER(RequirementBodySyntax,      requirement_body_syntax_trees)
+        DECLARE_SYNTAX_PARTITION_GETTER(TypeTemplateArgumentSyntax, type_template_argument_syntax_trees)
+        DECLARE_SYNTAX_PARTITION_GETTER(TemplateArgumentListSyntax, template_argument_list_syntax_trees)
+        DECLARE_SYNTAX_PARTITION_GETTER(TemplateIdSyntax,           templateid_syntax_trees)
+        DECLARE_SYNTAX_PARTITION_GETTER(TypeTraitIntrinsicSyntax,   type_trait_intrinsic_syntax_trees)
+        DECLARE_SYNTAX_PARTITION_GETTER(TupleSyntax,                tuple_syntax_trees)
+
+#undef DECLARE_SYNTAX_PARTITION_GETTER
 
         // Module References
-        Partition<ModuleReference, Index> imported_modules() const;
-        Partition<ModuleReference, Index> exported_modules() const;
+        DECLARE_UNTYPED_PARTITION_GETTER(ModuleReference, Index, imported_modules);
+        DECLARE_UNTYPED_PARTITION_GETTER(ModuleReference, Index, exported_modules);
 
         Partition<DeclIndex> deduction_guides() const;
+
+#undef DECLARE_PARTITION_GETTER
+#undef DECLARE_UNTYPED_PARTITION_GETTER
 
     public:
         // Traits
@@ -178,6 +218,13 @@ namespace ifc
 
         File           (File &&) noexcept;
         File& operator=(File &&) noexcept;
+
+    private:
+        template<typename T, typename Index>
+        Partition<T, Index> get_partition_with_cache(std::optional<Partition<T, Index>> & cache) const;
+
+        template<typename T, typename Index>
+        Partition<T, Index> get_partition_with_cache(std::optional<Partition<T, Index>> & cache, std::string_view) const;
 
     private:
         struct Impl;

--- a/lib/core/include/ifc/Partition.h
+++ b/lib/core/include/ifc/Partition.h
@@ -5,7 +5,6 @@
 #include "common_types.h"
 
 #include <cassert>
-#include <concepts>
 #include <ranges>
 
 namespace ifc

--- a/lib/core/include/ifc/Partition.h
+++ b/lib/core/include/ifc/Partition.h
@@ -5,6 +5,7 @@
 #include "common_types.h"
 
 #include <cassert>
+#include <concepts>
 #include <ranges>
 
 namespace ifc
@@ -34,12 +35,23 @@ namespace ifc
         return ref.index;
     }
 
+    template<typename T, typename Index>
+    concept CanValidateIndexSort = requires(Index index)
+    {
+        { T::Sort };
+        { index.sort() };
+    };
+
     template<typename T, typename Index = uint32_t>
     class Partition : public std::ranges::view_base
     {
     public:
         T const & operator[] (Index index) const
         {
+            if constexpr (CanValidateIndexSort<T, Index>)
+            {
+                assert(index.sort() == T::Sort);
+            }
             return data_[static_cast<size_t>(get_raw_index(index))];
         }
 
@@ -68,21 +80,5 @@ namespace ifc
     private:
         T const* data_;
         size_t size_;
-    };
-
-    template<typename T, typename Index>
-    class TypedPartition : public Partition<T, Index>
-    {
-    public:
-        explicit TypedPartition(Partition<T, Index> untyped)
-            : Partition<T, Index>(untyped)
-        {
-        }
-
-        T const& operator[] (Index index) const
-        {
-            assert(index.sort() == T::Sort);
-            return Partition<T, Index>::operator[](index);
-        }
     };
 }

--- a/lib/core/src/File.cpp
+++ b/lib/core/src/File.cpp
@@ -127,6 +127,20 @@ namespace ifc
             return { get_pointer<T>(partition->offset), raw_count(partition->cardinality) };
         }
 
+        template<typename T, typename Index>
+        Partition<T, Index> get_and_cache_partition() const
+        {
+            return get_and_cache_partition<T, Index>(T::PartitionName);
+        }
+
+        template<typename T, typename Index>
+        Partition<T, Index> get_and_cache_partition(std::string_view name) const
+        {
+            static Partition<T, Index> partition = try_get_partition<T, Index>(name)
+                .value_or(Partition<T, Index>{nullptr, 0});
+            return partition;
+        }
+
         std::unordered_map<DeclIndex, std::vector<AttrIndex>> const & trait_declaration_attributes()
         {
             if (!trait_declaration_attributes_)
@@ -194,6 +208,8 @@ namespace ifc
         std::optional<std::unordered_map<DeclIndex, Sequence>> trait_friendship_of_class_;
     };
 
+    // ------------------------------------------------------------------------
+
     FileHeader const& File::header() const
     {
         return impl_->header();
@@ -224,194 +240,558 @@ namespace ifc
         return impl_->get_raw_pointer(partition.offset);
     }
 
+    // ------------------------------------------------------------------------
+
     Partition<Declaration, Index> File::declarations() const
     {
-        return get_partition_with_cache<Declaration, Index>(cached_declarations_);
+        return impl_->get_and_cache_partition<Declaration, Index>();
     }
 
-#define DEFINE_PARTITION_GETTER(ElementType, IndexType, Property)   \
-    TypedPartition<ElementType, IndexType> File::Property() const { \
-        return static_cast<TypedPartition<ElementType, IndexType>>( \
-            get_partition_with_cache<ElementType, IndexType>(       \
-                cached_ ## Property ## _)                           \
-            );                                                      \
+    // ------------------------------------------------------------------------
+
+    Partition<ScopeDeclaration, DeclIndex>      File::scope_declarations() const
+    {
+        return impl_->get_and_cache_partition<ScopeDeclaration, DeclIndex>();
     }
 
-#define DEFINE_DECL_PARTITION_GETTER(DeclType, DeclName) \
-    DEFINE_PARTITION_GETTER(DeclType, DeclIndex, DeclName)
+    Partition<TemplateDeclaration, DeclIndex>   File::template_declarations() const
+    {
+        return impl_->get_and_cache_partition<TemplateDeclaration, DeclIndex>();
+    }
 
-    DEFINE_DECL_PARTITION_GETTER(ScopeDeclaration,      scope_declarations)
-    DEFINE_DECL_PARTITION_GETTER(TemplateDeclaration,   template_declarations)
-    DEFINE_DECL_PARTITION_GETTER(PartialSpecialization, partial_specializations)
-    DEFINE_DECL_PARTITION_GETTER(Specialization,        specializations)
-    DEFINE_DECL_PARTITION_GETTER(UsingDeclaration,      using_declarations)
-    DEFINE_DECL_PARTITION_GETTER(Enumeration,           enumerations)
-    DEFINE_DECL_PARTITION_GETTER(Enumerator,            enumerators)
-    DEFINE_DECL_PARTITION_GETTER(AliasDeclaration,      alias_declarations)
-    DEFINE_DECL_PARTITION_GETTER(DeclReference,         decl_references)
-    DEFINE_DECL_PARTITION_GETTER(FunctionDeclaration,   functions)
-    DEFINE_DECL_PARTITION_GETTER(MethodDeclaration,     methods)
-    DEFINE_DECL_PARTITION_GETTER(Constructor,           constructors)
-    DEFINE_DECL_PARTITION_GETTER(Destructor,            destructors)
-    DEFINE_DECL_PARTITION_GETTER(VariableDeclaration,   variables)
-    DEFINE_DECL_PARTITION_GETTER(FieldDeclaration,      fields)
-    DEFINE_DECL_PARTITION_GETTER(ParameterDeclaration,  parameters)
-    DEFINE_DECL_PARTITION_GETTER(Concept,               concepts)
-    DEFINE_DECL_PARTITION_GETTER(FriendDeclaration,     friends)
-    DEFINE_DECL_PARTITION_GETTER(IntrinsicDeclaration,  intrinsic_declarations)
+    Partition<PartialSpecialization, DeclIndex> File::partial_specializations() const
+    {
+        return impl_->get_and_cache_partition<PartialSpecialization, DeclIndex>();
+    }
 
-#undef DEFINE_DECL_PARTITION_GETTER
+    Partition<Specialization, DeclIndex>        File::specializations() const
+    {
+        return impl_->get_and_cache_partition<Specialization, DeclIndex>();
+    }
+
+    Partition<UsingDeclaration, DeclIndex>      File::using_declarations() const
+    {
+        return impl_->get_and_cache_partition<UsingDeclaration, DeclIndex>();
+    }
+
+    Partition<Enumeration, DeclIndex>           File::enumerations() const
+    {
+        return impl_->get_and_cache_partition<Enumeration, DeclIndex>();
+    }
+
+    Partition<Enumerator, DeclIndex>            File::enumerators() const
+    {
+        return impl_->get_and_cache_partition<Enumerator, DeclIndex>();
+    }
+
+    Partition<AliasDeclaration, DeclIndex>      File::alias_declarations() const
+    {
+        return impl_->get_and_cache_partition<AliasDeclaration, DeclIndex>();
+    }
+
+    Partition<DeclReference, DeclIndex>         File::decl_references() const
+    {
+        return impl_->get_and_cache_partition<DeclReference, DeclIndex>();
+    }
+
+    Partition<FunctionDeclaration, DeclIndex>   File::functions() const
+    {
+        return impl_->get_and_cache_partition<FunctionDeclaration, DeclIndex>();
+    }
+
+    Partition<MethodDeclaration, DeclIndex>     File::methods() const
+    {
+        return impl_->get_and_cache_partition<MethodDeclaration, DeclIndex>();
+    }
+
+    Partition<Constructor, DeclIndex>           File::constructors() const
+    {
+        return impl_->get_and_cache_partition<Constructor, DeclIndex>();
+    }
+
+    Partition<Destructor, DeclIndex>            File::destructors() const
+    {
+        return impl_->get_and_cache_partition<Destructor, DeclIndex>();
+    }
+
+    Partition<VariableDeclaration, DeclIndex>   File::variables() const
+    {
+        return impl_->get_and_cache_partition<VariableDeclaration, DeclIndex>();
+    }
+
+    Partition<ParameterDeclaration, DeclIndex>  File::parameters() const
+    {
+        return impl_->get_and_cache_partition<ParameterDeclaration, DeclIndex>();
+    }
+
+    Partition<FieldDeclaration, DeclIndex>      File::fields() const
+    {
+        return impl_->get_and_cache_partition<FieldDeclaration, DeclIndex>();
+    }
+
+    Partition<FriendDeclaration, DeclIndex>     File::friends() const
+    {
+        return impl_->get_and_cache_partition<FriendDeclaration, DeclIndex>();
+    }
+
+    Partition<Concept, DeclIndex>               File::concepts() const
+    {
+        return impl_->get_and_cache_partition<Concept, DeclIndex>();
+    }
+
+    Partition<IntrinsicDeclaration, DeclIndex>  File::intrinsic_declarations() const
+    {
+        return impl_->get_and_cache_partition<IntrinsicDeclaration, DeclIndex>();
+    }
+
+    // ------------------------------------------------------------------------
 
     Partition<SpecializationForm, SpecFormIndex> File::specialization_forms() const
     {
-        return get_partition_with_cache<SpecializationForm, SpecFormIndex>( cached_specialization_forms_);
+        return impl_->get_and_cache_partition<SpecializationForm, SpecFormIndex>();
     }
 
-#define DEFINE_TYPE_PARTITION_GETTER(Type, TypeName) \
-    DEFINE_PARTITION_GETTER(Type, TypeIndex, TypeName)
+    // ------------------------------------------------------------------------
 
-    DEFINE_TYPE_PARTITION_GETTER(FundamentalType,    fundamental_types)
-    DEFINE_TYPE_PARTITION_GETTER(DesignatedType,     designated_types)
-    DEFINE_TYPE_PARTITION_GETTER(TorType,            tor_types)
-    DEFINE_TYPE_PARTITION_GETTER(SyntacticType,      syntactic_types)
-    DEFINE_TYPE_PARTITION_GETTER(ExpansionType,      expansion_types)
-    DEFINE_TYPE_PARTITION_GETTER(PointerType,        pointer_types)
-    DEFINE_TYPE_PARTITION_GETTER(FunctionType,       function_types)
-    DEFINE_TYPE_PARTITION_GETTER(MethodType,         method_types)
-    DEFINE_TYPE_PARTITION_GETTER(ArrayType,          array_types)
-    DEFINE_TYPE_PARTITION_GETTER(BaseType,           base_types)
-    DEFINE_TYPE_PARTITION_GETTER(TupleType,          tuple_types)
-    DEFINE_TYPE_PARTITION_GETTER(LvalueReference,    lvalue_references)
-    DEFINE_TYPE_PARTITION_GETTER(RvalueReference,    rvalue_references)
-    DEFINE_TYPE_PARTITION_GETTER(QualifiedType,      qualified_types)
-    DEFINE_TYPE_PARTITION_GETTER(ForallType,         forall_types)
-    DEFINE_TYPE_PARTITION_GETTER(SyntaxType,         syntax_types)
-    DEFINE_TYPE_PARTITION_GETTER(PlaceholderType,    placeholder_types)
-    DEFINE_TYPE_PARTITION_GETTER(TypenameType,       typename_types)
-    DEFINE_TYPE_PARTITION_GETTER(DecltypeType,       decltype_types)
+    Partition<FundamentalType, TypeIndex>    File::fundamental_types() const 
+    {
+        return impl_->get_and_cache_partition<FundamentalType, TypeIndex>();
+    }
+    
+    Partition<DesignatedType, TypeIndex>     File::designated_types() const 
+    {
+        return impl_->get_and_cache_partition<DesignatedType, TypeIndex>();
+    }
+    
+    Partition<TorType, TypeIndex>            File::tor_types() const 
+    {
+        return impl_->get_and_cache_partition<TorType, TypeIndex>();
+    }
+    
+    Partition<SyntacticType, TypeIndex>      File::syntactic_types() const 
+    {
+        return impl_->get_and_cache_partition<SyntacticType, TypeIndex>();
+    }
+    
+    Partition<ExpansionType, TypeIndex>      File::expansion_types() const 
+    {
+        return impl_->get_and_cache_partition<ExpansionType, TypeIndex>();
+    }
+    
+    Partition<PointerType, TypeIndex>        File::pointer_types() const 
+    {
+        return impl_->get_and_cache_partition<PointerType, TypeIndex>();
+    }
+    
+    Partition<FunctionType, TypeIndex>       File::function_types() const 
+    {
+        return impl_->get_and_cache_partition<FunctionType, TypeIndex>();
+    }
+    
+    Partition<MethodType, TypeIndex>         File::method_types() const 
+    {
+        return impl_->get_and_cache_partition<MethodType, TypeIndex>();
+    }
+    
+    Partition<ArrayType, TypeIndex>          File::array_types() const 
+    {
+        return impl_->get_and_cache_partition<ArrayType, TypeIndex>();
+    }
+    
+    Partition<BaseType, TypeIndex>           File::base_types() const 
+    {
+        return impl_->get_and_cache_partition<BaseType, TypeIndex>();
+    }
+    
+    Partition<TupleType, TypeIndex>          File::tuple_types() const 
+    {
+        return impl_->get_and_cache_partition<TupleType, TypeIndex>();
+    }
+    
+    Partition<LvalueReference, TypeIndex>    File::lvalue_references() const 
+    {
+        return impl_->get_and_cache_partition<LvalueReference, TypeIndex>();
+    }
+    
+    Partition<RvalueReference, TypeIndex>    File::rvalue_references() const 
+    {
+        return impl_->get_and_cache_partition<RvalueReference, TypeIndex>();
+    }
+    
+    Partition<QualifiedType, TypeIndex>      File::qualified_types() const 
+    {
+        return impl_->get_and_cache_partition<QualifiedType, TypeIndex>();
+    }
+    
+    Partition<ForallType, TypeIndex>         File::forall_types() const 
+    {
+        return impl_->get_and_cache_partition<ForallType, TypeIndex>();
+    }
+    
+    Partition<SyntaxType, TypeIndex>         File::syntax_types() const 
+    {
+        return impl_->get_and_cache_partition<SyntaxType, TypeIndex>();
+    }
+    
+    Partition<PlaceholderType, TypeIndex>    File::placeholder_types() const 
+    {
+        return impl_->get_and_cache_partition<PlaceholderType, TypeIndex>();
+    }
+    
+    Partition<TypenameType, TypeIndex>       File::typename_types() const 
+    {
+        return impl_->get_and_cache_partition<TypenameType, TypeIndex>();
+    }
+    
+    Partition<DecltypeType, TypeIndex>       File::decltype_types() const 
+    {
+        return impl_->get_and_cache_partition<DecltypeType, TypeIndex>();
+    }
 
-#undef DEFINE_TYPE_PARTITION_GETTER
+    // ------------------------------------------------------------------------
 
-#define DEFINE_ATTR_PARTITION_GETTER(DeclType, DeclName) \
-    DEFINE_PARTITION_GETTER(DeclType, AttrIndex, DeclName)
+    Partition<AttrBasic, AttrIndex> File::basic_attributes() const
+    {
+        return impl_->get_and_cache_partition<AttrBasic, AttrIndex>();
+    }
 
-        DEFINE_ATTR_PARTITION_GETTER(AttrBasic, basic_attributes)
-        DEFINE_ATTR_PARTITION_GETTER(AttrScoped, scoped_attributes)
-        DEFINE_ATTR_PARTITION_GETTER(AttrLabeled, labeled_attributes)
-        DEFINE_ATTR_PARTITION_GETTER(AttrCalled, called_attributes)
-        DEFINE_ATTR_PARTITION_GETTER(AttrExpanded, expanded_attributes)
-        DEFINE_ATTR_PARTITION_GETTER(AttrFactored, factored_attributes)
-        DEFINE_ATTR_PARTITION_GETTER(AttrElaborated, elaborated_attributes)
-        DEFINE_ATTR_PARTITION_GETTER(AttrTuple, tuple_attributes)
+    Partition<AttrScoped, AttrIndex> File::scoped_attributes() const
+    {
+        return impl_->get_and_cache_partition<AttrScoped, AttrIndex>();
+    }
 
-#undef DEFINE_ATTR_PARTITION_GETTER
+    Partition<AttrLabeled, AttrIndex> File::labeled_attributes() const
+    {
+        return impl_->get_and_cache_partition<AttrLabeled, AttrIndex>();
+    }
 
-#define DEFINE_EXPR_PARTITION_GETTER(ExprType, ExprName) \
-    DEFINE_PARTITION_GETTER(ExprType, ExprIndex, ExprName)
+    Partition<AttrCalled, AttrIndex> File::called_attributes() const
+    {
+        return impl_->get_and_cache_partition<AttrCalled, AttrIndex>();
+    }
 
-    DEFINE_EXPR_PARTITION_GETTER(LiteralExpression, literal_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(TypeExpression,    type_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(NamedDecl,         decl_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(UnqualifiedId,     unqualified_id_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(TemplateId,        template_ids)
-    DEFINE_EXPR_PARTITION_GETTER(TemplateReference, template_references)
-    DEFINE_EXPR_PARTITION_GETTER(MonadExpression,   monad_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(DyadExpression,    dyad_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(StringExpression,  string_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(CallExpression,    call_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(SizeofExpression,  sizeof_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(AlignofExpression, alignof_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(RequiresExpression,requires_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(TupleExpression,   tuple_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(PathExpression,    path_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(ReadExpression,    read_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(SyntaxTreeExpression, syntax_tree_expressions)
+    Partition<AttrExpanded, AttrIndex> File::expanded_attributes() const
+    {
+        return impl_->get_and_cache_partition<AttrExpanded, AttrIndex>();
+    }
 
-    DEFINE_EXPR_PARTITION_GETTER(ExpressionListExpression,expression_lists)
-    DEFINE_EXPR_PARTITION_GETTER(QualifiedNameExpression, qualified_name_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(PackedTemplateArguments, packed_template_arguments)
-    DEFINE_EXPR_PARTITION_GETTER(ProductValueTypeExpression, product_value_type_expressions)
+    Partition<AttrFactored, AttrIndex> File::factored_attributes() const
+    {
+        return impl_->get_and_cache_partition<AttrFactored, AttrIndex>();
+    }
+
+    Partition<AttrElaborated, AttrIndex> File::elaborated_attributes() const
+    {
+        return impl_->get_and_cache_partition<AttrElaborated, AttrIndex>();
+    }
+
+    Partition<AttrTuple, AttrIndex> File::tuple_attributes() const
+    {
+        return impl_->get_and_cache_partition<AttrTuple, AttrIndex>();
+    }
+
+    // ------------------------------------------------------------------------
+
+    Partition<LiteralExpression, ExprIndex>  File::literal_expressions() const
+    {
+        return impl_->get_and_cache_partition<LiteralExpression, ExprIndex>();
+    }
+
+    Partition<TypeExpression, ExprIndex>     File::type_expressions() const
+    {
+        return impl_->get_and_cache_partition<TypeExpression, ExprIndex>();
+    }
+
+    Partition<NamedDecl, ExprIndex>          File::decl_expressions() const
+    {
+        return impl_->get_and_cache_partition<NamedDecl, ExprIndex>();
+    }
+
+    Partition<UnqualifiedId, ExprIndex>      File::unqualified_id_expressions() const
+    {
+        return impl_->get_and_cache_partition<UnqualifiedId, ExprIndex>();
+    }
+
+    Partition<TemplateId, ExprIndex>         File::template_ids() const
+    {
+        return impl_->get_and_cache_partition<TemplateId, ExprIndex>();
+    }
+
+    Partition<TemplateReference, ExprIndex>  File::template_references() const
+    {
+        return impl_->get_and_cache_partition<TemplateReference, ExprIndex>();
+    }
+
+    Partition<MonadExpression, ExprIndex>    File::monad_expressions() const
+    {
+        return impl_->get_and_cache_partition<MonadExpression, ExprIndex>();
+    }
+
+    Partition<DyadExpression, ExprIndex>     File::dyad_expressions() const
+    {
+        return impl_->get_and_cache_partition<DyadExpression, ExprIndex>();
+    }
+
+    Partition<StringExpression, ExprIndex>   File::string_expressions() const
+    {
+        return impl_->get_and_cache_partition<StringExpression, ExprIndex>();
+    }
+
+    Partition<CallExpression, ExprIndex>     File::call_expressions() const
+    {
+        return impl_->get_and_cache_partition<CallExpression, ExprIndex>();
+    }
+
+    Partition<SizeofExpression, ExprIndex>   File::sizeof_expressions() const
+    {
+        return impl_->get_and_cache_partition<SizeofExpression, ExprIndex>();
+    }
+
+    Partition<AlignofExpression, ExprIndex>  File::alignof_expressions() const
+    {
+        return impl_->get_and_cache_partition<AlignofExpression, ExprIndex>();
+    }
+
+    Partition<RequiresExpression, ExprIndex> File::requires_expressions() const
+    {
+        return impl_->get_and_cache_partition<RequiresExpression, ExprIndex>();
+    }
+
+    Partition<TupleExpression, ExprIndex>    File::tuple_expressions() const
+    {
+        return impl_->get_and_cache_partition<TupleExpression, ExprIndex>();
+    }
+
+    Partition<PathExpression, ExprIndex>     File::path_expressions() const
+    {
+        return impl_->get_and_cache_partition<PathExpression, ExprIndex>();
+    }
+
+    Partition<ReadExpression, ExprIndex>     File::read_expressions() const
+    {
+        return impl_->get_and_cache_partition<ReadExpression, ExprIndex>();
+    }
+
+    Partition<SyntaxTreeExpression, ExprIndex>  File::syntax_tree_expressions() const
+    {
+        return impl_->get_and_cache_partition<SyntaxTreeExpression, ExprIndex>();
+    }
+
+    // ------------------------------------------------------------------------
+
+    Partition<ExpressionListExpression, ExprIndex> File::expression_lists() const
+    {
+        return impl_->get_and_cache_partition<ExpressionListExpression, ExprIndex>();
+    }
+
+    Partition<QualifiedNameExpression, ExprIndex>  File::qualified_name_expressions() const
+    {
+        return impl_->get_and_cache_partition<QualifiedNameExpression, ExprIndex>();
+    }
+
+    Partition<PackedTemplateArguments, ExprIndex>  File::packed_template_arguments() const
+    {
+        return impl_->get_and_cache_partition<PackedTemplateArguments, ExprIndex>();
+    }
+
+    Partition<ProductValueTypeExpression, ExprIndex>  File::product_value_type_expressions() const
+    {
+        return impl_->get_and_cache_partition<ProductValueTypeExpression, ExprIndex>();
+    }
+
+    // ------------------------------------------------------------------------
 
     Partition<StringLiteral, StringIndex> File::string_literal_expressions() const
     {
-        return get_partition_with_cache<StringLiteral, StringIndex>(cached_string_literal_expressions_);
+        return impl_->get_and_cache_partition<StringLiteral, StringIndex>();
     }
 
-#undef DEFINE_EXPR_PARTITION_GETTER
+    // ------------------------------------------------------------------------
 
-    DEFINE_PARTITION_GETTER(ChartUnilevel,   ChartIndex, unilevel_charts)
-    DEFINE_PARTITION_GETTER(ChartMultilevel, ChartIndex, multilevel_charts)
+    Partition<ChartUnilevel, ChartIndex>    File::unilevel_charts() const
+    {
+        return impl_->get_and_cache_partition<ChartUnilevel, ChartIndex>();
+    }
 
-    DEFINE_PARTITION_GETTER(IntegerLiteral,  LitIndex,   integer_literals)
-    DEFINE_PARTITION_GETTER(FPLiteral,       LitIndex,   fp_literals)
+    Partition<ChartMultilevel, ChartIndex>  File::multilevel_charts() const
+    {
+        return impl_->get_and_cache_partition<ChartMultilevel, ChartIndex>();
 
-#define DEFINE_SYNTAX_PARTITION_GETTER(SyntaxType, SyntaxName) \
-    DEFINE_PARTITION_GETTER(SyntaxType, SyntaxIndex, SyntaxName)
+    }
 
-    DEFINE_SYNTAX_PARTITION_GETTER(SimpleTypeSpecifier,         simple_type_specifiers)
-    DEFINE_SYNTAX_PARTITION_GETTER(DecltypeSpecifier,           decltype_specifiers)
-    DEFINE_SYNTAX_PARTITION_GETTER(TypeSpecifierSeq,            type_specifier_seq_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(DeclSpecifierSeq,            decl_specifier_seq_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(TypeIdSyntax,                typeid_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(DeclaratorSyntax,            declarator_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(PointerDeclaratorSyntax,     pointer_declarator_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(FunctionDeclaratorSyntax,    function_declarator_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(ParameterDeclaratorSyntax,   parameter_declarator_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(ExpressionSyntax,            expression_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(RequiresClauseSyntax,        requires_clause_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(SimpleRequirementSyntax,     simple_requirement_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(TypeRequirementSyntax,       type_requirement_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(NestedRequirementSyntax,     nested_requirement_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(CompoundRequirementSyntax,   compound_requirement_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(RequirementBodySyntax,       requirement_body_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(TypeTemplateArgumentSyntax,  type_template_argument_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(TemplateArgumentListSyntax,  template_argument_list_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(TemplateIdSyntax,            templateid_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(TypeTraitIntrinsicSyntax,    type_trait_intrinsic_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(TupleSyntax,                 tuple_syntax_trees)
+    Partition<IntegerLiteral, LitIndex> File::integer_literals() const 
+    {
+        return impl_->get_and_cache_partition<IntegerLiteral, LitIndex>();
+    }
+    Partition<FPLiteral, LitIndex>      File::fp_literals() const 
+    {
+        return impl_->get_and_cache_partition<FPLiteral, LitIndex>();
+    }
 
-#undef DEFINE_SYNTAX_PARTITION_GETTER
+    // ------------------------------------------------------------------------
 
-    DEFINE_PARTITION_GETTER(OperatorFunctionName, NameIndex, operator_names)
-    DEFINE_PARTITION_GETTER(SpecializationName,   NameIndex, specialization_names)
-    DEFINE_PARTITION_GETTER(LiteralName,          NameIndex, literal_names)
+    Partition<SimpleTypeSpecifier, SyntaxIndex>         File::simple_type_specifiers() const
+    {
+        return impl_->get_and_cache_partition<SimpleTypeSpecifier, SyntaxIndex>();
+    }
 
-#undef DEFINE_PARTITION_GETTER
+    Partition<DecltypeSpecifier, SyntaxIndex>           File::decltype_specifiers() const
+    {
+        return impl_->get_and_cache_partition<DecltypeSpecifier, SyntaxIndex>();
+    }
+
+    Partition<TypeSpecifierSeq, SyntaxIndex>            File::type_specifier_seq_syntax_trees() const
+    {
+        return impl_->get_and_cache_partition<TypeSpecifierSeq, SyntaxIndex>();
+    }
+
+    Partition<DeclSpecifierSeq, SyntaxIndex>            File::decl_specifier_seq_syntax_trees() const
+    {
+        return impl_->get_and_cache_partition<DeclSpecifierSeq, SyntaxIndex>();
+    }
+
+    Partition<TypeIdSyntax, SyntaxIndex>                File::typeid_syntax_trees() const
+    {
+        return impl_->get_and_cache_partition<TypeIdSyntax, SyntaxIndex>();
+    }
+
+    Partition<DeclaratorSyntax, SyntaxIndex>            File::declarator_syntax_trees() const
+    {
+        return impl_->get_and_cache_partition<DeclaratorSyntax, SyntaxIndex>();
+    }
+
+    Partition<PointerDeclaratorSyntax, SyntaxIndex>     File::pointer_declarator_syntax_trees() const
+    {
+        return impl_->get_and_cache_partition<PointerDeclaratorSyntax, SyntaxIndex>();
+    }
+
+    Partition<FunctionDeclaratorSyntax, SyntaxIndex>    File::function_declarator_syntax_trees() const
+    {
+        return impl_->get_and_cache_partition<FunctionDeclaratorSyntax, SyntaxIndex>();
+    }
+
+    Partition<ParameterDeclaratorSyntax, SyntaxIndex>   File::parameter_declarator_syntax_trees() const
+    {
+        return impl_->get_and_cache_partition<ParameterDeclaratorSyntax, SyntaxIndex>();
+    }
+
+    Partition<ExpressionSyntax, SyntaxIndex>            File::expression_syntax_trees() const
+    {
+        return impl_->get_and_cache_partition<ExpressionSyntax, SyntaxIndex>();
+    }
+
+    Partition<RequiresClauseSyntax, SyntaxIndex>        File::requires_clause_syntax_trees() const
+    {
+        return impl_->get_and_cache_partition<RequiresClauseSyntax, SyntaxIndex>();
+    }
+
+    Partition<SimpleRequirementSyntax, SyntaxIndex>     File::simple_requirement_syntax_trees() const
+    {
+        return impl_->get_and_cache_partition<SimpleRequirementSyntax, SyntaxIndex>();
+    }
+
+    Partition<TypeRequirementSyntax, SyntaxIndex>       File::type_requirement_syntax_trees() const
+    {
+        return impl_->get_and_cache_partition<TypeRequirementSyntax, SyntaxIndex>();
+    }
+
+    Partition<NestedRequirementSyntax, SyntaxIndex>     File::nested_requirement_syntax_trees() const
+    {
+        return impl_->get_and_cache_partition<NestedRequirementSyntax, SyntaxIndex>();
+    }
+
+    Partition<CompoundRequirementSyntax, SyntaxIndex>   File::compound_requirement_syntax_trees() const
+    {
+        return impl_->get_and_cache_partition<CompoundRequirementSyntax, SyntaxIndex>();
+    }
+
+    Partition<RequirementBodySyntax, SyntaxIndex>       File::requirement_body_syntax_trees() const
+    {
+        return impl_->get_and_cache_partition<RequirementBodySyntax, SyntaxIndex>();
+    }
+
+    Partition<TypeTemplateArgumentSyntax, SyntaxIndex>  File::type_template_argument_syntax_trees() const
+    {
+        return impl_->get_and_cache_partition<TypeTemplateArgumentSyntax, SyntaxIndex>();
+    }
+
+    Partition<TemplateArgumentListSyntax, SyntaxIndex>  File::template_argument_list_syntax_trees() const
+    {
+        return impl_->get_and_cache_partition<TemplateArgumentListSyntax, SyntaxIndex>();
+    }
+
+    Partition<TemplateIdSyntax, SyntaxIndex>            File::templateid_syntax_trees() const
+    {
+        return impl_->get_and_cache_partition<TemplateIdSyntax, SyntaxIndex>();
+    }
+
+    Partition<TypeTraitIntrinsicSyntax, SyntaxIndex>    File::type_trait_intrinsic_syntax_trees() const
+    {
+        return impl_->get_and_cache_partition<TypeTraitIntrinsicSyntax, SyntaxIndex>();
+    }
+
+    Partition<TupleSyntax, SyntaxIndex>                 File::tuple_syntax_trees() const
+    {
+        return impl_->get_and_cache_partition<TupleSyntax, SyntaxIndex>();
+    }
+
+    // ------------------------------------------------------------------------
+
+    Partition<OperatorFunctionName, NameIndex> File::operator_names() const
+    {
+        return impl_->get_and_cache_partition<OperatorFunctionName, NameIndex>();
+    }
+
+    Partition<SpecializationName, NameIndex> File::specialization_names() const
+    {
+        return impl_->get_and_cache_partition<SpecializationName, NameIndex>();
+    }
+
+    Partition<LiteralName, NameIndex> File::literal_names() const
+    {
+        return impl_->get_and_cache_partition<LiteralName, NameIndex>();
+    }
+
+    // ------------------------------------------------------------------------
 
     Partition<TypeIndex, Index> File::type_heap() const
     {
-        return get_partition_with_cache<TypeIndex, Index>(cached_type_heap_, "heap.type");
+        return impl_->get_and_cache_partition<TypeIndex, Index>("heap.type");
     }
 
     Partition<ExprIndex, Index> File::expr_heap() const
     {
-        return get_partition_with_cache<ExprIndex, Index>(cached_expr_heap_, "heap.expr");
+        return impl_->get_and_cache_partition<ExprIndex, Index>("heap.expr");
     }
 
     Partition<AttrIndex, Index> File::attr_heap() const
     {
-        return get_partition_with_cache<AttrIndex, Index>(cached_attr_heap_, "heap.attr");
+        return impl_->get_and_cache_partition<AttrIndex, Index>("heap.attr");
     }
 
     Partition<SyntaxIndex, Index> File::syntax_heap() const
     {
-        return get_partition_with_cache<SyntaxIndex, Index>(cached_syntax_heap_, "heap.syn");
+        return impl_->get_and_cache_partition<SyntaxIndex, Index>("heap.syn");
     }
 
     Partition<ModuleReference, Index> File::imported_modules() const
     {
-        return get_partition_with_cache<ModuleReference, Index>(cached_imported_modules_, "module.imported");
+        return impl_->get_and_cache_partition<ModuleReference, Index>("module.imported");
     }
 
     Partition<ModuleReference, Index> File::exported_modules() const
     {
-        return get_partition_with_cache<ModuleReference, Index>(cached_exported_modules_, "module.exported");
+        return impl_->get_and_cache_partition<ModuleReference, Index>("module.exported");
     }
+
+    // ------------------------------------------------------------------------
 
     Partition<DeclIndex> File::deduction_guides() const
     {
-        return impl_->get_partition<DeclIndex, uint32_t>("name.guide");
+        return impl_->get_and_cache_partition<DeclIndex, uint32_t>("name.guide");
     }
+
+    // ------------------------------------------------------------------------
 
     template<typename RetType, typename Value>
     RetType get_value(DeclIndex declaration, std::unordered_map<DeclIndex, Value> const & map)
@@ -437,21 +817,7 @@ namespace ifc
         return get_value<Sequence>(declaration, impl_->trait_friendship_of_class());
     }
 
-    template<typename T, typename Index>
-    Partition<T, Index> File::get_partition_with_cache(std::optional<Partition<T, Index>> & cache) const
-    {
-        return get_partition_with_cache<T, Index>(cache, T::PartitionName);
-    }
-
-    template <typename T, typename Index>
-    Partition<T, Index> File::get_partition_with_cache(std::optional<Partition<T, Index>>& cache, std::string_view name) const
-    {
-        if (cache.has_value())
-            return *cache;
-        auto result = impl_->get_partition<T, Index>(name);
-        cache = result;
-        return result;
-    }
+    // ------------------------------------------------------------------------
 
     File::File(BlobView data)
         : impl_(std::make_unique<Impl>(data))
@@ -462,6 +828,8 @@ namespace ifc
 
     File::File           (File&&) noexcept = default;
     File& File::operator=(File&&) noexcept = default;
+
+    // ------------------------------------------------------------------------
 
     ScopeDeclaration const& get_scope(File const& file, DeclIndex decl)
     {

--- a/lib/core/src/File.cpp
+++ b/lib/core/src/File.cpp
@@ -224,139 +224,92 @@ namespace ifc
         return impl_->get_raw_pointer(partition.offset);
     }
 
-    Partition<Declaration, Index> File::declarations() const
-    {
-        return get_partition_with_cache<Declaration, Index>(cached_declarations_);
-    }
-
 #define DEFINE_PARTITION_GETTER(ElementType, IndexType, Property)                           \
     Partition<ElementType, IndexType> File::Property() const {                              \
         return get_partition_with_cache<ElementType, IndexType>(cached_ ## Property ## _);  \
     }
 
     // Declarations
-    DEFINE_PARTITION_GETTER(ScopeDeclaration, DeclIndex, scope_declarations)
-    DEFINE_PARTITION_GETTER(TemplateDeclaration, DeclIndex, template_declarations)
-    DEFINE_PARTITION_GETTER(PartialSpecialization, DeclIndex, partial_specializations)
-    DEFINE_PARTITION_GETTER(Specialization, DeclIndex, specializations)
-    DEFINE_PARTITION_GETTER(UsingDeclaration, DeclIndex, using_declarations)
-    DEFINE_PARTITION_GETTER(Enumeration, DeclIndex, enumerations)
-    DEFINE_PARTITION_GETTER(Enumerator, DeclIndex, enumerators)
-    DEFINE_PARTITION_GETTER(AliasDeclaration, DeclIndex, alias_declarations)
-    DEFINE_PARTITION_GETTER(DeclReference, DeclIndex, decl_references)
-    DEFINE_PARTITION_GETTER(FunctionDeclaration, DeclIndex, functions)
-    DEFINE_PARTITION_GETTER(MethodDeclaration, DeclIndex, methods)
-    DEFINE_PARTITION_GETTER(Constructor, DeclIndex, constructors)
-    DEFINE_PARTITION_GETTER(Destructor, DeclIndex, destructors)
-    DEFINE_PARTITION_GETTER(VariableDeclaration, DeclIndex, variables)
-    DEFINE_PARTITION_GETTER(FieldDeclaration, DeclIndex, fields)
-    DEFINE_PARTITION_GETTER(ParameterDeclaration, DeclIndex, parameters)
-    DEFINE_PARTITION_GETTER(Concept, DeclIndex, concepts)
-    DEFINE_PARTITION_GETTER(FriendDeclaration, DeclIndex, friends)
-    DEFINE_PARTITION_GETTER(IntrinsicDeclaration, DeclIndex,  intrinsic_declarations)
+    DEFINE_PARTITION_GETTER(Declaration,            Index,          declarations)
+    
+    DEFINE_PARTITION_GETTER(ScopeDeclaration,       DeclIndex,      scope_declarations)
+    DEFINE_PARTITION_GETTER(TemplateDeclaration,    DeclIndex,      template_declarations)
+    DEFINE_PARTITION_GETTER(PartialSpecialization,  DeclIndex,      partial_specializations)
+    DEFINE_PARTITION_GETTER(Specialization,         DeclIndex,      specializations)
+    DEFINE_PARTITION_GETTER(UsingDeclaration,       DeclIndex,      using_declarations)
+    DEFINE_PARTITION_GETTER(Enumeration,            DeclIndex,      enumerations)
+    DEFINE_PARTITION_GETTER(Enumerator,             DeclIndex,      enumerators)
+    DEFINE_PARTITION_GETTER(AliasDeclaration,       DeclIndex,      alias_declarations)
+    DEFINE_PARTITION_GETTER(DeclReference,          DeclIndex,      decl_references)
+    DEFINE_PARTITION_GETTER(FunctionDeclaration,    DeclIndex,      functions)
+    DEFINE_PARTITION_GETTER(MethodDeclaration,      DeclIndex,      methods)
+    DEFINE_PARTITION_GETTER(Constructor,            DeclIndex,      constructors)
+    DEFINE_PARTITION_GETTER(Destructor,             DeclIndex,      destructors)
+    DEFINE_PARTITION_GETTER(VariableDeclaration,    DeclIndex,      variables)
+    DEFINE_PARTITION_GETTER(FieldDeclaration,       DeclIndex,      fields)
+    DEFINE_PARTITION_GETTER(ParameterDeclaration,   DeclIndex,      parameters)
+    DEFINE_PARTITION_GETTER(Concept,                DeclIndex,      concepts)
+    DEFINE_PARTITION_GETTER(FriendDeclaration,      DeclIndex,      friends)
+    DEFINE_PARTITION_GETTER(IntrinsicDeclaration,   DeclIndex,      intrinsic_declarations)
 
-    Partition<SpecializationForm, SpecFormIndex> File::specialization_forms() const
-    {
-        return get_partition_with_cache<SpecializationForm, SpecFormIndex>( cached_specialization_forms_);
-    }
+    DEFINE_PARTITION_GETTER(SpecializationForm,     SpecFormIndex,  specialization_forms)
 
     // Types
-    DEFINE_PARTITION_GETTER(FundamentalType, TypeIndex, fundamental_types)
-    DEFINE_PARTITION_GETTER(DesignatedType, TypeIndex, designated_types)
-    DEFINE_PARTITION_GETTER(TorType, TypeIndex, tor_types)
-    DEFINE_PARTITION_GETTER(SyntacticType, TypeIndex, syntactic_types)
-    DEFINE_PARTITION_GETTER(ExpansionType, TypeIndex, expansion_types)
-    DEFINE_PARTITION_GETTER(PointerType, TypeIndex, pointer_types)
-    DEFINE_PARTITION_GETTER(FunctionType, TypeIndex, function_types)
-    DEFINE_PARTITION_GETTER(MethodType, TypeIndex, method_types)
-    DEFINE_PARTITION_GETTER(ArrayType, TypeIndex, array_types)
-    DEFINE_PARTITION_GETTER(BaseType, TypeIndex, base_types)
-    DEFINE_PARTITION_GETTER(TupleType, TypeIndex, tuple_types)
-    DEFINE_PARTITION_GETTER(LvalueReference, TypeIndex, lvalue_references)
-    DEFINE_PARTITION_GETTER(RvalueReference, TypeIndex, rvalue_references)
-    DEFINE_PARTITION_GETTER(QualifiedType, TypeIndex, qualified_types)
-    DEFINE_PARTITION_GETTER(ForallType, TypeIndex, forall_types)
-    DEFINE_PARTITION_GETTER(SyntaxType, TypeIndex, syntax_types)
-    DEFINE_PARTITION_GETTER(PlaceholderType, TypeIndex, placeholder_types)
-    DEFINE_PARTITION_GETTER(TypenameType, TypeIndex, typename_types)
-    DEFINE_PARTITION_GETTER(DecltypeType,       TypeIndex, decltype_types)
+    DEFINE_PARTITION_GETTER(FundamentalType,    TypeIndex,  fundamental_types)
+    DEFINE_PARTITION_GETTER(DesignatedType,     TypeIndex,  designated_types)
+    DEFINE_PARTITION_GETTER(TorType,            TypeIndex,  tor_types)
+    DEFINE_PARTITION_GETTER(SyntacticType,      TypeIndex,  syntactic_types)
+    DEFINE_PARTITION_GETTER(ExpansionType,      TypeIndex,  expansion_types)
+    DEFINE_PARTITION_GETTER(PointerType,        TypeIndex,  pointer_types)
+    DEFINE_PARTITION_GETTER(FunctionType,       TypeIndex,  function_types)
+    DEFINE_PARTITION_GETTER(MethodType,         TypeIndex,  method_types)
+    DEFINE_PARTITION_GETTER(ArrayType,          TypeIndex,  array_types)
+    DEFINE_PARTITION_GETTER(BaseType,           TypeIndex,  base_types)
+    DEFINE_PARTITION_GETTER(TupleType,          TypeIndex,  tuple_types)
+    DEFINE_PARTITION_GETTER(LvalueReference,    TypeIndex,  lvalue_references)
+    DEFINE_PARTITION_GETTER(RvalueReference,    TypeIndex,  rvalue_references)
+    DEFINE_PARTITION_GETTER(QualifiedType,      TypeIndex,  qualified_types)
+    DEFINE_PARTITION_GETTER(ForallType,         TypeIndex,  forall_types)
+    DEFINE_PARTITION_GETTER(SyntaxType,         TypeIndex,  syntax_types)
+    DEFINE_PARTITION_GETTER(PlaceholderType,    TypeIndex,  placeholder_types)
+    DEFINE_PARTITION_GETTER(TypenameType,       TypeIndex,  typename_types)
+    DEFINE_PARTITION_GETTER(DecltypeType,       TypeIndex,  decltype_types)
 
     // Attributes
-    DEFINE_PARTITION_GETTER(AttrBasic, AttrIndex, basic_attributes)
-    DEFINE_PARTITION_GETTER(AttrScoped, AttrIndex, scoped_attributes)
-    DEFINE_PARTITION_GETTER(AttrLabeled, AttrIndex, labeled_attributes)
-    DEFINE_PARTITION_GETTER(AttrCalled, AttrIndex, called_attributes)
-    DEFINE_PARTITION_GETTER(AttrExpanded, AttrIndex, expanded_attributes)
-    DEFINE_PARTITION_GETTER(AttrFactored, AttrIndex, factored_attributes)
-    DEFINE_PARTITION_GETTER(AttrElaborated, AttrIndex, elaborated_attributes)
-    DEFINE_PARTITION_GETTER(AttrTuple, AttrIndex, tuple_attributes)
+    DEFINE_PARTITION_GETTER(AttrBasic,      AttrIndex,  basic_attributes)
+    DEFINE_PARTITION_GETTER(AttrScoped,     AttrIndex,  scoped_attributes)
+    DEFINE_PARTITION_GETTER(AttrLabeled,    AttrIndex,  labeled_attributes)
+    DEFINE_PARTITION_GETTER(AttrCalled,     AttrIndex,  called_attributes)
+    DEFINE_PARTITION_GETTER(AttrExpanded,   AttrIndex,  expanded_attributes)
+    DEFINE_PARTITION_GETTER(AttrFactored,   AttrIndex,  factored_attributes)
+    DEFINE_PARTITION_GETTER(AttrElaborated, AttrIndex,  elaborated_attributes)
+    DEFINE_PARTITION_GETTER(AttrTuple,      AttrIndex,  tuple_attributes)
 
     // Expressions
-    DEFINE_PARTITION_GETTER(LiteralExpression, ExprIndex, literal_expressions)
-    DEFINE_PARTITION_GETTER(TypeExpression, ExprIndex, type_expressions)
-    DEFINE_PARTITION_GETTER(NamedDecl, ExprIndex, decl_expressions)
-    DEFINE_PARTITION_GETTER(UnqualifiedId, ExprIndex, unqualified_id_expressions)
-    DEFINE_PARTITION_GETTER(TemplateId, ExprIndex, template_ids)
-    DEFINE_PARTITION_GETTER(TemplateReference, ExprIndex, template_references)
-    DEFINE_PARTITION_GETTER(MonadExpression, ExprIndex, monad_expressions)
-    DEFINE_PARTITION_GETTER(DyadExpression, ExprIndex, dyad_expressions)
-    DEFINE_PARTITION_GETTER(StringExpression, ExprIndex, string_expressions)
-    DEFINE_PARTITION_GETTER(CallExpression, ExprIndex, call_expressions)
-    DEFINE_PARTITION_GETTER(SizeofExpression, ExprIndex, sizeof_expressions)
-    DEFINE_PARTITION_GETTER(AlignofExpression, ExprIndex, alignof_expressions)
-    DEFINE_PARTITION_GETTER(RequiresExpression, ExprIndex, requires_expressions)
-    DEFINE_PARTITION_GETTER(TupleExpression, ExprIndex, tuple_expressions)
-    DEFINE_PARTITION_GETTER(PathExpression, ExprIndex, path_expressions)
-    DEFINE_PARTITION_GETTER(ReadExpression, ExprIndex, read_expressions)
-    DEFINE_PARTITION_GETTER(SyntaxTreeExpression, ExprIndex, syntax_tree_expressions)
+    DEFINE_PARTITION_GETTER(LiteralExpression,          ExprIndex,      literal_expressions)
+    DEFINE_PARTITION_GETTER(TypeExpression,             ExprIndex,      type_expressions)
+    DEFINE_PARTITION_GETTER(NamedDecl,                  ExprIndex,      decl_expressions)
+    DEFINE_PARTITION_GETTER(UnqualifiedId,              ExprIndex,      unqualified_id_expressions)
+    DEFINE_PARTITION_GETTER(TemplateId,                 ExprIndex,      template_ids)
+    DEFINE_PARTITION_GETTER(TemplateReference,          ExprIndex,      template_references)
+    DEFINE_PARTITION_GETTER(MonadExpression,            ExprIndex,      monad_expressions)
+    DEFINE_PARTITION_GETTER(DyadExpression,             ExprIndex,      dyad_expressions)
+    DEFINE_PARTITION_GETTER(StringExpression,           ExprIndex,      string_expressions)
+    DEFINE_PARTITION_GETTER(CallExpression,             ExprIndex,      call_expressions)
+    DEFINE_PARTITION_GETTER(SizeofExpression,           ExprIndex,      sizeof_expressions)
+    DEFINE_PARTITION_GETTER(AlignofExpression,          ExprIndex,      alignof_expressions)
+    DEFINE_PARTITION_GETTER(RequiresExpression,         ExprIndex,      requires_expressions)
+    DEFINE_PARTITION_GETTER(TupleExpression,            ExprIndex,      tuple_expressions)
+    DEFINE_PARTITION_GETTER(PathExpression,             ExprIndex,      path_expressions)
+    DEFINE_PARTITION_GETTER(ReadExpression,             ExprIndex,      read_expressions)
+    DEFINE_PARTITION_GETTER(SyntaxTreeExpression,       ExprIndex,      syntax_tree_expressions)
 
-    DEFINE_PARTITION_GETTER(ExpressionListExpression, ExprIndex, expression_lists)
-    DEFINE_PARTITION_GETTER(QualifiedNameExpression, ExprIndex, qualified_name_expressions)
-    DEFINE_PARTITION_GETTER(PackedTemplateArguments, ExprIndex, packed_template_arguments)
-    DEFINE_PARTITION_GETTER(ProductValueTypeExpression, ExprIndex, product_value_type_expressions)
+    DEFINE_PARTITION_GETTER(ExpressionListExpression,   ExprIndex,      expression_lists)
+    DEFINE_PARTITION_GETTER(QualifiedNameExpression,    ExprIndex,      qualified_name_expressions)
+    DEFINE_PARTITION_GETTER(PackedTemplateArguments,    ExprIndex,      packed_template_arguments)
+    DEFINE_PARTITION_GETTER(ProductValueTypeExpression, ExprIndex,      product_value_type_expressions)
 
-    Partition<StringLiteral, StringIndex> File::string_literal_expressions() const
-    {
-        return get_partition_with_cache<StringLiteral, StringIndex>(cached_string_literal_expressions_);
-    }
-
-    // Charts
-    DEFINE_PARTITION_GETTER(ChartUnilevel,   ChartIndex, unilevel_charts)
-    DEFINE_PARTITION_GETTER(ChartMultilevel, ChartIndex, multilevel_charts)
-
-    // Literals
-    DEFINE_PARTITION_GETTER(IntegerLiteral,  LitIndex,   integer_literals)
-    DEFINE_PARTITION_GETTER(FPLiteral,       LitIndex,   fp_literals)
-    
-    // Syntax Trees
-    DEFINE_PARTITION_GETTER(SimpleTypeSpecifier, SyntaxIndex, simple_type_specifiers)
-    DEFINE_PARTITION_GETTER(DecltypeSpecifier, SyntaxIndex, decltype_specifiers)
-    DEFINE_PARTITION_GETTER(TypeSpecifierSeq, SyntaxIndex, type_specifier_seq_syntax_trees)
-    DEFINE_PARTITION_GETTER(DeclSpecifierSeq, SyntaxIndex, decl_specifier_seq_syntax_trees)
-    DEFINE_PARTITION_GETTER(TypeIdSyntax, SyntaxIndex, typeid_syntax_trees)
-    DEFINE_PARTITION_GETTER(DeclaratorSyntax, SyntaxIndex, declarator_syntax_trees)
-    DEFINE_PARTITION_GETTER(PointerDeclaratorSyntax, SyntaxIndex, pointer_declarator_syntax_trees)
-    DEFINE_PARTITION_GETTER(FunctionDeclaratorSyntax, SyntaxIndex, function_declarator_syntax_trees)
-    DEFINE_PARTITION_GETTER(ParameterDeclaratorSyntax, SyntaxIndex, parameter_declarator_syntax_trees)
-    DEFINE_PARTITION_GETTER(ExpressionSyntax, SyntaxIndex, expression_syntax_trees)
-    DEFINE_PARTITION_GETTER(RequiresClauseSyntax, SyntaxIndex, requires_clause_syntax_trees)
-    DEFINE_PARTITION_GETTER(SimpleRequirementSyntax, SyntaxIndex, simple_requirement_syntax_trees)
-    DEFINE_PARTITION_GETTER(TypeRequirementSyntax, SyntaxIndex, type_requirement_syntax_trees)
-    DEFINE_PARTITION_GETTER(NestedRequirementSyntax, SyntaxIndex, nested_requirement_syntax_trees)
-    DEFINE_PARTITION_GETTER(CompoundRequirementSyntax, SyntaxIndex, compound_requirement_syntax_trees)
-    DEFINE_PARTITION_GETTER(RequirementBodySyntax, SyntaxIndex, requirement_body_syntax_trees)
-    DEFINE_PARTITION_GETTER(TypeTemplateArgumentSyntax, SyntaxIndex, type_template_argument_syntax_trees)
-    DEFINE_PARTITION_GETTER(TemplateArgumentListSyntax, SyntaxIndex, template_argument_list_syntax_trees)
-    DEFINE_PARTITION_GETTER(TemplateIdSyntax, SyntaxIndex, templateid_syntax_trees)
-    DEFINE_PARTITION_GETTER(TypeTraitIntrinsicSyntax, SyntaxIndex, type_trait_intrinsic_syntax_trees)
-    DEFINE_PARTITION_GETTER(TupleSyntax, SyntaxIndex, tuple_syntax_trees)
-
-    // Names
-    DEFINE_PARTITION_GETTER(OperatorFunctionName, NameIndex, operator_names)
-    DEFINE_PARTITION_GETTER(SpecializationName,   NameIndex, specialization_names)
-    DEFINE_PARTITION_GETTER(LiteralName,          NameIndex, literal_names)
-
-#undef DEFINE_PARTITION_GETTER
+    DEFINE_PARTITION_GETTER(StringLiteral,              StringIndex,    string_literal_expressions)
 
     // Heaps
     Partition<TypeIndex, Index> File::type_heap() const
@@ -379,6 +332,42 @@ namespace ifc
         return get_partition_with_cache<SyntaxIndex, Index>(cached_syntax_heap_, "heap.syn");
     }
 
+    // Names
+    DEFINE_PARTITION_GETTER(OperatorFunctionName,   NameIndex,  operator_names)
+    DEFINE_PARTITION_GETTER(SpecializationName,     NameIndex,  specialization_names)
+    DEFINE_PARTITION_GETTER(LiteralName,            NameIndex,  literal_names)
+
+    // Charts
+    DEFINE_PARTITION_GETTER(ChartUnilevel,      ChartIndex, unilevel_charts)
+    DEFINE_PARTITION_GETTER(ChartMultilevel,    ChartIndex, multilevel_charts)
+
+    // Literals
+    DEFINE_PARTITION_GETTER(IntegerLiteral, LitIndex,   integer_literals)
+    DEFINE_PARTITION_GETTER(FPLiteral,      LitIndex,   fp_literals)
+    
+    // Syntax Trees
+    DEFINE_PARTITION_GETTER(SimpleTypeSpecifier,        SyntaxIndex,    simple_type_specifiers)
+    DEFINE_PARTITION_GETTER(DecltypeSpecifier,          SyntaxIndex,    decltype_specifiers)
+    DEFINE_PARTITION_GETTER(TypeSpecifierSeq,           SyntaxIndex,    type_specifier_seq_syntax_trees)
+    DEFINE_PARTITION_GETTER(DeclSpecifierSeq,           SyntaxIndex,    decl_specifier_seq_syntax_trees)
+    DEFINE_PARTITION_GETTER(TypeIdSyntax,               SyntaxIndex,    typeid_syntax_trees)
+    DEFINE_PARTITION_GETTER(DeclaratorSyntax,           SyntaxIndex,    declarator_syntax_trees)
+    DEFINE_PARTITION_GETTER(PointerDeclaratorSyntax,    SyntaxIndex,    pointer_declarator_syntax_trees)
+    DEFINE_PARTITION_GETTER(FunctionDeclaratorSyntax,   SyntaxIndex,    function_declarator_syntax_trees)
+    DEFINE_PARTITION_GETTER(ParameterDeclaratorSyntax,  SyntaxIndex,    parameter_declarator_syntax_trees)
+    DEFINE_PARTITION_GETTER(ExpressionSyntax,           SyntaxIndex,    expression_syntax_trees)
+    DEFINE_PARTITION_GETTER(RequiresClauseSyntax,       SyntaxIndex,    requires_clause_syntax_trees)
+    DEFINE_PARTITION_GETTER(SimpleRequirementSyntax,    SyntaxIndex,    simple_requirement_syntax_trees)
+    DEFINE_PARTITION_GETTER(TypeRequirementSyntax,      SyntaxIndex,    type_requirement_syntax_trees)
+    DEFINE_PARTITION_GETTER(NestedRequirementSyntax,    SyntaxIndex,    nested_requirement_syntax_trees)
+    DEFINE_PARTITION_GETTER(CompoundRequirementSyntax,  SyntaxIndex,    compound_requirement_syntax_trees)
+    DEFINE_PARTITION_GETTER(RequirementBodySyntax,      SyntaxIndex,    requirement_body_syntax_trees)
+    DEFINE_PARTITION_GETTER(TypeTemplateArgumentSyntax, SyntaxIndex,    type_template_argument_syntax_trees)
+    DEFINE_PARTITION_GETTER(TemplateArgumentListSyntax, SyntaxIndex,    template_argument_list_syntax_trees)
+    DEFINE_PARTITION_GETTER(TemplateIdSyntax,           SyntaxIndex,    templateid_syntax_trees)
+    DEFINE_PARTITION_GETTER(TypeTraitIntrinsicSyntax,   SyntaxIndex,    type_trait_intrinsic_syntax_trees)
+    DEFINE_PARTITION_GETTER(TupleSyntax,                SyntaxIndex,    tuple_syntax_trees)
+
     // Module References
     Partition<ModuleReference, Index> File::imported_modules() const
     {
@@ -393,8 +382,10 @@ namespace ifc
     // Deduction Guides
     Partition<DeclIndex> File::deduction_guides() const
     {
-        return impl_->get_partition<DeclIndex, uint32_t>("name.guide");
+        return get_partition_with_cache<DeclIndex, uint32_t>(cached_deduction_guides_, "name.guide");
     }
+
+#undef DEFINE_PARTITION_GETTER
 
     template<typename RetType, typename Value>
     RetType get_value(DeclIndex declaration, std::unordered_map<DeclIndex, Value> const & map)

--- a/lib/core/src/File.cpp
+++ b/lib/core/src/File.cpp
@@ -229,155 +229,136 @@ namespace ifc
         return get_partition_with_cache<Declaration, Index>(cached_declarations_);
     }
 
-#define DEFINE_PARTITION_GETTER(ElementType, IndexType, Property)   \
-    TypedPartition<ElementType, IndexType> File::Property() const { \
-        return static_cast<TypedPartition<ElementType, IndexType>>( \
-            get_partition_with_cache<ElementType, IndexType>(       \
-                cached_ ## Property ## _)                           \
-            );                                                      \
+#define DEFINE_PARTITION_GETTER(ElementType, IndexType, Property)                           \
+    Partition<ElementType, IndexType> File::Property() const {                              \
+        return get_partition_with_cache<ElementType, IndexType>(cached_ ## Property ## _);  \
     }
 
-#define DEFINE_DECL_PARTITION_GETTER(DeclType, DeclName) \
-    DEFINE_PARTITION_GETTER(DeclType, DeclIndex, DeclName)
-
-    DEFINE_DECL_PARTITION_GETTER(ScopeDeclaration,      scope_declarations)
-    DEFINE_DECL_PARTITION_GETTER(TemplateDeclaration,   template_declarations)
-    DEFINE_DECL_PARTITION_GETTER(PartialSpecialization, partial_specializations)
-    DEFINE_DECL_PARTITION_GETTER(Specialization,        specializations)
-    DEFINE_DECL_PARTITION_GETTER(UsingDeclaration,      using_declarations)
-    DEFINE_DECL_PARTITION_GETTER(Enumeration,           enumerations)
-    DEFINE_DECL_PARTITION_GETTER(Enumerator,            enumerators)
-    DEFINE_DECL_PARTITION_GETTER(AliasDeclaration,      alias_declarations)
-    DEFINE_DECL_PARTITION_GETTER(DeclReference,         decl_references)
-    DEFINE_DECL_PARTITION_GETTER(FunctionDeclaration,   functions)
-    DEFINE_DECL_PARTITION_GETTER(MethodDeclaration,     methods)
-    DEFINE_DECL_PARTITION_GETTER(Constructor,           constructors)
-    DEFINE_DECL_PARTITION_GETTER(Destructor,            destructors)
-    DEFINE_DECL_PARTITION_GETTER(VariableDeclaration,   variables)
-    DEFINE_DECL_PARTITION_GETTER(FieldDeclaration,      fields)
-    DEFINE_DECL_PARTITION_GETTER(ParameterDeclaration,  parameters)
-    DEFINE_DECL_PARTITION_GETTER(Concept,               concepts)
-    DEFINE_DECL_PARTITION_GETTER(FriendDeclaration,     friends)
-    DEFINE_DECL_PARTITION_GETTER(IntrinsicDeclaration,  intrinsic_declarations)
-
-#undef DEFINE_DECL_PARTITION_GETTER
+    // Declarations
+    DEFINE_PARTITION_GETTER(ScopeDeclaration, DeclIndex, scope_declarations)
+    DEFINE_PARTITION_GETTER(TemplateDeclaration, DeclIndex, template_declarations)
+    DEFINE_PARTITION_GETTER(PartialSpecialization, DeclIndex, partial_specializations)
+    DEFINE_PARTITION_GETTER(Specialization, DeclIndex, specializations)
+    DEFINE_PARTITION_GETTER(UsingDeclaration, DeclIndex, using_declarations)
+    DEFINE_PARTITION_GETTER(Enumeration, DeclIndex, enumerations)
+    DEFINE_PARTITION_GETTER(Enumerator, DeclIndex, enumerators)
+    DEFINE_PARTITION_GETTER(AliasDeclaration, DeclIndex, alias_declarations)
+    DEFINE_PARTITION_GETTER(DeclReference, DeclIndex, decl_references)
+    DEFINE_PARTITION_GETTER(FunctionDeclaration, DeclIndex, functions)
+    DEFINE_PARTITION_GETTER(MethodDeclaration, DeclIndex, methods)
+    DEFINE_PARTITION_GETTER(Constructor, DeclIndex, constructors)
+    DEFINE_PARTITION_GETTER(Destructor, DeclIndex, destructors)
+    DEFINE_PARTITION_GETTER(VariableDeclaration, DeclIndex, variables)
+    DEFINE_PARTITION_GETTER(FieldDeclaration, DeclIndex, fields)
+    DEFINE_PARTITION_GETTER(ParameterDeclaration, DeclIndex, parameters)
+    DEFINE_PARTITION_GETTER(Concept, DeclIndex, concepts)
+    DEFINE_PARTITION_GETTER(FriendDeclaration, DeclIndex, friends)
+    DEFINE_PARTITION_GETTER(IntrinsicDeclaration, DeclIndex,  intrinsic_declarations)
 
     Partition<SpecializationForm, SpecFormIndex> File::specialization_forms() const
     {
         return get_partition_with_cache<SpecializationForm, SpecFormIndex>( cached_specialization_forms_);
     }
 
-#define DEFINE_TYPE_PARTITION_GETTER(Type, TypeName) \
-    DEFINE_PARTITION_GETTER(Type, TypeIndex, TypeName)
+    // Types
+    DEFINE_PARTITION_GETTER(FundamentalType, TypeIndex, fundamental_types)
+    DEFINE_PARTITION_GETTER(DesignatedType, TypeIndex, designated_types)
+    DEFINE_PARTITION_GETTER(TorType, TypeIndex, tor_types)
+    DEFINE_PARTITION_GETTER(SyntacticType, TypeIndex, syntactic_types)
+    DEFINE_PARTITION_GETTER(ExpansionType, TypeIndex, expansion_types)
+    DEFINE_PARTITION_GETTER(PointerType, TypeIndex, pointer_types)
+    DEFINE_PARTITION_GETTER(FunctionType, TypeIndex, function_types)
+    DEFINE_PARTITION_GETTER(MethodType, TypeIndex, method_types)
+    DEFINE_PARTITION_GETTER(ArrayType, TypeIndex, array_types)
+    DEFINE_PARTITION_GETTER(BaseType, TypeIndex, base_types)
+    DEFINE_PARTITION_GETTER(TupleType, TypeIndex, tuple_types)
+    DEFINE_PARTITION_GETTER(LvalueReference, TypeIndex, lvalue_references)
+    DEFINE_PARTITION_GETTER(RvalueReference, TypeIndex, rvalue_references)
+    DEFINE_PARTITION_GETTER(QualifiedType, TypeIndex, qualified_types)
+    DEFINE_PARTITION_GETTER(ForallType, TypeIndex, forall_types)
+    DEFINE_PARTITION_GETTER(SyntaxType, TypeIndex, syntax_types)
+    DEFINE_PARTITION_GETTER(PlaceholderType, TypeIndex, placeholder_types)
+    DEFINE_PARTITION_GETTER(TypenameType, TypeIndex, typename_types)
+    DEFINE_PARTITION_GETTER(DecltypeType,       TypeIndex, decltype_types)
 
-    DEFINE_TYPE_PARTITION_GETTER(FundamentalType,    fundamental_types)
-    DEFINE_TYPE_PARTITION_GETTER(DesignatedType,     designated_types)
-    DEFINE_TYPE_PARTITION_GETTER(TorType,            tor_types)
-    DEFINE_TYPE_PARTITION_GETTER(SyntacticType,      syntactic_types)
-    DEFINE_TYPE_PARTITION_GETTER(ExpansionType,      expansion_types)
-    DEFINE_TYPE_PARTITION_GETTER(PointerType,        pointer_types)
-    DEFINE_TYPE_PARTITION_GETTER(FunctionType,       function_types)
-    DEFINE_TYPE_PARTITION_GETTER(MethodType,         method_types)
-    DEFINE_TYPE_PARTITION_GETTER(ArrayType,          array_types)
-    DEFINE_TYPE_PARTITION_GETTER(BaseType,           base_types)
-    DEFINE_TYPE_PARTITION_GETTER(TupleType,          tuple_types)
-    DEFINE_TYPE_PARTITION_GETTER(LvalueReference,    lvalue_references)
-    DEFINE_TYPE_PARTITION_GETTER(RvalueReference,    rvalue_references)
-    DEFINE_TYPE_PARTITION_GETTER(QualifiedType,      qualified_types)
-    DEFINE_TYPE_PARTITION_GETTER(ForallType,         forall_types)
-    DEFINE_TYPE_PARTITION_GETTER(SyntaxType,         syntax_types)
-    DEFINE_TYPE_PARTITION_GETTER(PlaceholderType,    placeholder_types)
-    DEFINE_TYPE_PARTITION_GETTER(TypenameType,       typename_types)
-    DEFINE_TYPE_PARTITION_GETTER(DecltypeType,       decltype_types)
+    // Attributes
+    DEFINE_PARTITION_GETTER(AttrBasic, AttrIndex, basic_attributes)
+    DEFINE_PARTITION_GETTER(AttrScoped, AttrIndex, scoped_attributes)
+    DEFINE_PARTITION_GETTER(AttrLabeled, AttrIndex, labeled_attributes)
+    DEFINE_PARTITION_GETTER(AttrCalled, AttrIndex, called_attributes)
+    DEFINE_PARTITION_GETTER(AttrExpanded, AttrIndex, expanded_attributes)
+    DEFINE_PARTITION_GETTER(AttrFactored, AttrIndex, factored_attributes)
+    DEFINE_PARTITION_GETTER(AttrElaborated, AttrIndex, elaborated_attributes)
+    DEFINE_PARTITION_GETTER(AttrTuple, AttrIndex, tuple_attributes)
 
-#undef DEFINE_TYPE_PARTITION_GETTER
+    // Expressions
+    DEFINE_PARTITION_GETTER(LiteralExpression, ExprIndex, literal_expressions)
+    DEFINE_PARTITION_GETTER(TypeExpression, ExprIndex, type_expressions)
+    DEFINE_PARTITION_GETTER(NamedDecl, ExprIndex, decl_expressions)
+    DEFINE_PARTITION_GETTER(UnqualifiedId, ExprIndex, unqualified_id_expressions)
+    DEFINE_PARTITION_GETTER(TemplateId, ExprIndex, template_ids)
+    DEFINE_PARTITION_GETTER(TemplateReference, ExprIndex, template_references)
+    DEFINE_PARTITION_GETTER(MonadExpression, ExprIndex, monad_expressions)
+    DEFINE_PARTITION_GETTER(DyadExpression, ExprIndex, dyad_expressions)
+    DEFINE_PARTITION_GETTER(StringExpression, ExprIndex, string_expressions)
+    DEFINE_PARTITION_GETTER(CallExpression, ExprIndex, call_expressions)
+    DEFINE_PARTITION_GETTER(SizeofExpression, ExprIndex, sizeof_expressions)
+    DEFINE_PARTITION_GETTER(AlignofExpression, ExprIndex, alignof_expressions)
+    DEFINE_PARTITION_GETTER(RequiresExpression, ExprIndex, requires_expressions)
+    DEFINE_PARTITION_GETTER(TupleExpression, ExprIndex, tuple_expressions)
+    DEFINE_PARTITION_GETTER(PathExpression, ExprIndex, path_expressions)
+    DEFINE_PARTITION_GETTER(ReadExpression, ExprIndex, read_expressions)
+    DEFINE_PARTITION_GETTER(SyntaxTreeExpression, ExprIndex, syntax_tree_expressions)
 
-#define DEFINE_ATTR_PARTITION_GETTER(DeclType, DeclName) \
-    DEFINE_PARTITION_GETTER(DeclType, AttrIndex, DeclName)
-
-        DEFINE_ATTR_PARTITION_GETTER(AttrBasic, basic_attributes)
-        DEFINE_ATTR_PARTITION_GETTER(AttrScoped, scoped_attributes)
-        DEFINE_ATTR_PARTITION_GETTER(AttrLabeled, labeled_attributes)
-        DEFINE_ATTR_PARTITION_GETTER(AttrCalled, called_attributes)
-        DEFINE_ATTR_PARTITION_GETTER(AttrExpanded, expanded_attributes)
-        DEFINE_ATTR_PARTITION_GETTER(AttrFactored, factored_attributes)
-        DEFINE_ATTR_PARTITION_GETTER(AttrElaborated, elaborated_attributes)
-        DEFINE_ATTR_PARTITION_GETTER(AttrTuple, tuple_attributes)
-
-#undef DEFINE_ATTR_PARTITION_GETTER
-
-#define DEFINE_EXPR_PARTITION_GETTER(ExprType, ExprName) \
-    DEFINE_PARTITION_GETTER(ExprType, ExprIndex, ExprName)
-
-    DEFINE_EXPR_PARTITION_GETTER(LiteralExpression, literal_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(TypeExpression,    type_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(NamedDecl,         decl_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(UnqualifiedId,     unqualified_id_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(TemplateId,        template_ids)
-    DEFINE_EXPR_PARTITION_GETTER(TemplateReference, template_references)
-    DEFINE_EXPR_PARTITION_GETTER(MonadExpression,   monad_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(DyadExpression,    dyad_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(StringExpression,  string_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(CallExpression,    call_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(SizeofExpression,  sizeof_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(AlignofExpression, alignof_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(RequiresExpression,requires_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(TupleExpression,   tuple_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(PathExpression,    path_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(ReadExpression,    read_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(SyntaxTreeExpression, syntax_tree_expressions)
-
-    DEFINE_EXPR_PARTITION_GETTER(ExpressionListExpression,expression_lists)
-    DEFINE_EXPR_PARTITION_GETTER(QualifiedNameExpression, qualified_name_expressions)
-    DEFINE_EXPR_PARTITION_GETTER(PackedTemplateArguments, packed_template_arguments)
-    DEFINE_EXPR_PARTITION_GETTER(ProductValueTypeExpression, product_value_type_expressions)
+    DEFINE_PARTITION_GETTER(ExpressionListExpression, ExprIndex, expression_lists)
+    DEFINE_PARTITION_GETTER(QualifiedNameExpression, ExprIndex, qualified_name_expressions)
+    DEFINE_PARTITION_GETTER(PackedTemplateArguments, ExprIndex, packed_template_arguments)
+    DEFINE_PARTITION_GETTER(ProductValueTypeExpression, ExprIndex, product_value_type_expressions)
 
     Partition<StringLiteral, StringIndex> File::string_literal_expressions() const
     {
         return get_partition_with_cache<StringLiteral, StringIndex>(cached_string_literal_expressions_);
     }
 
-#undef DEFINE_EXPR_PARTITION_GETTER
-
+    // Charts
     DEFINE_PARTITION_GETTER(ChartUnilevel,   ChartIndex, unilevel_charts)
     DEFINE_PARTITION_GETTER(ChartMultilevel, ChartIndex, multilevel_charts)
 
+    // Literals
     DEFINE_PARTITION_GETTER(IntegerLiteral,  LitIndex,   integer_literals)
     DEFINE_PARTITION_GETTER(FPLiteral,       LitIndex,   fp_literals)
+    
+    // Syntax Trees
+    DEFINE_PARTITION_GETTER(SimpleTypeSpecifier, SyntaxIndex, simple_type_specifiers)
+    DEFINE_PARTITION_GETTER(DecltypeSpecifier, SyntaxIndex, decltype_specifiers)
+    DEFINE_PARTITION_GETTER(TypeSpecifierSeq, SyntaxIndex, type_specifier_seq_syntax_trees)
+    DEFINE_PARTITION_GETTER(DeclSpecifierSeq, SyntaxIndex, decl_specifier_seq_syntax_trees)
+    DEFINE_PARTITION_GETTER(TypeIdSyntax, SyntaxIndex, typeid_syntax_trees)
+    DEFINE_PARTITION_GETTER(DeclaratorSyntax, SyntaxIndex, declarator_syntax_trees)
+    DEFINE_PARTITION_GETTER(PointerDeclaratorSyntax, SyntaxIndex, pointer_declarator_syntax_trees)
+    DEFINE_PARTITION_GETTER(FunctionDeclaratorSyntax, SyntaxIndex, function_declarator_syntax_trees)
+    DEFINE_PARTITION_GETTER(ParameterDeclaratorSyntax, SyntaxIndex, parameter_declarator_syntax_trees)
+    DEFINE_PARTITION_GETTER(ExpressionSyntax, SyntaxIndex, expression_syntax_trees)
+    DEFINE_PARTITION_GETTER(RequiresClauseSyntax, SyntaxIndex, requires_clause_syntax_trees)
+    DEFINE_PARTITION_GETTER(SimpleRequirementSyntax, SyntaxIndex, simple_requirement_syntax_trees)
+    DEFINE_PARTITION_GETTER(TypeRequirementSyntax, SyntaxIndex, type_requirement_syntax_trees)
+    DEFINE_PARTITION_GETTER(NestedRequirementSyntax, SyntaxIndex, nested_requirement_syntax_trees)
+    DEFINE_PARTITION_GETTER(CompoundRequirementSyntax, SyntaxIndex, compound_requirement_syntax_trees)
+    DEFINE_PARTITION_GETTER(RequirementBodySyntax, SyntaxIndex, requirement_body_syntax_trees)
+    DEFINE_PARTITION_GETTER(TypeTemplateArgumentSyntax, SyntaxIndex, type_template_argument_syntax_trees)
+    DEFINE_PARTITION_GETTER(TemplateArgumentListSyntax, SyntaxIndex, template_argument_list_syntax_trees)
+    DEFINE_PARTITION_GETTER(TemplateIdSyntax, SyntaxIndex, templateid_syntax_trees)
+    DEFINE_PARTITION_GETTER(TypeTraitIntrinsicSyntax, SyntaxIndex, type_trait_intrinsic_syntax_trees)
+    DEFINE_PARTITION_GETTER(TupleSyntax, SyntaxIndex, tuple_syntax_trees)
 
-#define DEFINE_SYNTAX_PARTITION_GETTER(SyntaxType, SyntaxName) \
-    DEFINE_PARTITION_GETTER(SyntaxType, SyntaxIndex, SyntaxName)
-
-    DEFINE_SYNTAX_PARTITION_GETTER(SimpleTypeSpecifier,         simple_type_specifiers)
-    DEFINE_SYNTAX_PARTITION_GETTER(DecltypeSpecifier,           decltype_specifiers)
-    DEFINE_SYNTAX_PARTITION_GETTER(TypeSpecifierSeq,            type_specifier_seq_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(DeclSpecifierSeq,            decl_specifier_seq_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(TypeIdSyntax,                typeid_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(DeclaratorSyntax,            declarator_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(PointerDeclaratorSyntax,     pointer_declarator_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(FunctionDeclaratorSyntax,    function_declarator_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(ParameterDeclaratorSyntax,   parameter_declarator_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(ExpressionSyntax,            expression_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(RequiresClauseSyntax,        requires_clause_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(SimpleRequirementSyntax,     simple_requirement_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(TypeRequirementSyntax,       type_requirement_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(NestedRequirementSyntax,     nested_requirement_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(CompoundRequirementSyntax,   compound_requirement_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(RequirementBodySyntax,       requirement_body_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(TypeTemplateArgumentSyntax,  type_template_argument_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(TemplateArgumentListSyntax,  template_argument_list_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(TemplateIdSyntax,            templateid_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(TypeTraitIntrinsicSyntax,    type_trait_intrinsic_syntax_trees)
-    DEFINE_SYNTAX_PARTITION_GETTER(TupleSyntax,                 tuple_syntax_trees)
-
-#undef DEFINE_SYNTAX_PARTITION_GETTER
-
+    // Names
     DEFINE_PARTITION_GETTER(OperatorFunctionName, NameIndex, operator_names)
     DEFINE_PARTITION_GETTER(SpecializationName,   NameIndex, specialization_names)
     DEFINE_PARTITION_GETTER(LiteralName,          NameIndex, literal_names)
 
 #undef DEFINE_PARTITION_GETTER
 
+    // Heaps
     Partition<TypeIndex, Index> File::type_heap() const
     {
         return get_partition_with_cache<TypeIndex, Index>(cached_type_heap_, "heap.type");
@@ -398,6 +379,7 @@ namespace ifc
         return get_partition_with_cache<SyntaxIndex, Index>(cached_syntax_heap_, "heap.syn");
     }
 
+    // Module References
     Partition<ModuleReference, Index> File::imported_modules() const
     {
         return get_partition_with_cache<ModuleReference, Index>(cached_imported_modules_, "module.imported");
@@ -408,6 +390,7 @@ namespace ifc
         return get_partition_with_cache<ModuleReference, Index>(cached_exported_modules_, "module.exported");
     }
 
+    // Deduction Guides
     Partition<DeclIndex> File::deduction_guides() const
     {
         return impl_->get_partition<DeclIndex, uint32_t>("name.guide");


### PR DESCRIPTION
To me this code is more readable. Following the call sites is now very straightforward instead of looking at nested macro's.

It also previously initialized the partition cache in a thread unsafe manner. By using a local static the initialization is guaranteed to be threadsafe.