### PR TITLE
Added Hash and compare #26

### DIFF
--- a/lib/core/include/ifc/AbstractReference.h
+++ b/lib/core/include/ifc/AbstractReference.h
@@ -25,7 +25,7 @@ namespace ifc
             return tag == 0 && index == 0;
         }
 
-        bool operator==(const AbstractReference& rhs) const = default;
+        auto operator<=>(const AbstractReference& rhs) const = default;
     };
 }
 

--- a/lib/reflifc/include/reflifc/Attribute.h
+++ b/lib/reflifc/include/reflifc/Attribute.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "HashCombine.h"
+
 #include <ifc/FileFwd.h>
 #include <ifc/AttributeFwd.h>
 
@@ -23,7 +25,11 @@ namespace reflifc
         bool            is_called() const;
         AttributeCalled as_called() const;
 
+        auto operator<=>(Attribute const& other) const = default;
+
     private:
+        friend std::hash<Attribute>;
+
         ifc::File const* ifc_;
         ifc::AttrIndex index_;
     };
@@ -39,8 +45,30 @@ namespace reflifc
         Attribute function() const;
         Attribute arguments() const;
 
+        auto operator<=>(AttributeCalled const& other) const = default;
+
     private:
+        friend std::hash<AttributeCalled>;
+
         ifc::File const* ifc_;
         ifc::AttrCalled const* attr_;
     };
 }
+
+template<>
+struct std::hash<reflifc::Attribute>
+{
+    size_t operator()(reflifc::Attribute const& attribute) const noexcept
+    {
+        return reflifc::hash_combine(0, attribute.ifc_, attribute.index_);
+    }
+};
+
+template<>
+struct std::hash<reflifc::AttributeCalled>
+{
+    size_t operator()(reflifc::AttributeCalled const& attribute_called) const noexcept
+    {
+        return reflifc::hash_combine(0, attribute_called.ifc_, attribute_called.attr_);
+    }
+};

--- a/lib/reflifc/include/reflifc/Attribute.h
+++ b/lib/reflifc/include/reflifc/Attribute.h
@@ -58,7 +58,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::Attribute>
 {
-    size_t operator()(reflifc::Attribute const& attribute) const noexcept
+    size_t operator()(reflifc::Attribute attribute) const noexcept
     {
         return reflifc::hash_combine(0, attribute.ifc_, attribute.index_);
     }
@@ -67,7 +67,7 @@ struct std::hash<reflifc::Attribute>
 template<>
 struct std::hash<reflifc::AttributeCalled>
 {
-    size_t operator()(reflifc::AttributeCalled const& attribute_called) const noexcept
+    size_t operator()(reflifc::AttributeCalled attribute_called) const noexcept
     {
         return reflifc::hash_combine(0, attribute_called.ifc_, attribute_called.attr_);
     }

--- a/lib/reflifc/include/reflifc/Chart.h
+++ b/lib/reflifc/include/reflifc/Chart.h
@@ -67,7 +67,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::Chart>
 {
-    size_t operator()(reflifc::Chart const& object) const noexcept
+    size_t operator()(reflifc::Chart object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.index_);
     }
@@ -76,7 +76,7 @@ struct std::hash<reflifc::Chart>
 template<>
 struct std::hash<reflifc::ChartUnilevel>
 {
-    size_t operator()(reflifc::ChartUnilevel const& object) const noexcept
+    size_t operator()(reflifc::ChartUnilevel object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.unilevel_);
     }

--- a/lib/reflifc/include/reflifc/Chart.h
+++ b/lib/reflifc/include/reflifc/Chart.h
@@ -3,6 +3,7 @@
 #include "reflifc/decl/Parameter.h"
 
 #include "ViewOf.h"
+#include "HashCombine.h"
 
 #include <ifc/Chart.h>
 #include <ifc/File.h>
@@ -23,7 +24,11 @@ namespace reflifc
 
         ifc::ChartSort sort() const { return index_.sort(); }
 
+        auto operator<=>(Chart const& other) const = default;
+
     private:
+        friend std::hash<Chart>;
+
         ifc::File const* ifc_;
         ifc::ChartIndex index_;
     };
@@ -49,8 +54,30 @@ namespace reflifc
         bool        has_constraint()    const;
         Expression  constraint()        const;
 
+        auto operator<=>(ChartUnilevel const& other) const = default;
+
     private:
+        friend std::hash<ChartUnilevel>;
+
         ifc::File const* ifc_;
         ifc::ChartUnilevel const* unilevel_;
     };
 }
+
+template<>
+struct std::hash<reflifc::Chart>
+{
+    size_t operator()(reflifc::Chart const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.index_);
+    }
+};
+
+template<>
+struct std::hash<reflifc::ChartUnilevel>
+{
+    size_t operator()(reflifc::ChartUnilevel const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.unilevel_);
+    }
+};

--- a/lib/reflifc/include/reflifc/Declaration.h
+++ b/lib/reflifc/include/reflifc/Declaration.h
@@ -3,6 +3,7 @@
 #include "Attribute.h"
 #include "Expression.h"
 #include "ViewOf.h"
+#include "HashCombine.h"
 
 #include <ifc/File.h>
 #include <ifc/Declaration.h>
@@ -112,14 +113,21 @@ namespace reflifc
         ifc::DeclSort sort() const { return index_.sort(); }
         ifc::DeclIndex index() const { return index_; }
 
-        bool operator==(Declaration other) const
-        {
-            assert(ifc_ == other.ifc_);
-            return index_ == other.index_;
-        }
+        auto operator<=>(Declaration const& other) const = default;
 
     private:
+        friend std::hash<Declaration>;
+
         ifc::File const* ifc_;
         ifc::DeclIndex index_;
     };
 }
+
+template<>
+struct std::hash<reflifc::Declaration>
+{
+    size_t operator()(reflifc::Declaration const& decl) const noexcept
+    {
+        return reflifc::hash_combine(0, decl.ifc_, decl.index_);
+    }
+};

--- a/lib/reflifc/include/reflifc/Declaration.h
+++ b/lib/reflifc/include/reflifc/Declaration.h
@@ -115,7 +115,7 @@ namespace reflifc
 
         ifc::File const* containing_file() const { return ifc_; }
 
-        auto operator<=>(Declaration other) const = default;
+        auto operator<=>(Declaration const& other) const = default;
 
     private:
         friend std::hash<Declaration>;

--- a/lib/reflifc/include/reflifc/Expression.h
+++ b/lib/reflifc/include/reflifc/Expression.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "HashCombine.h"
+
 #include <ifc/ExpressionFwd.h>
 #include <ifc/FileFwd.h>
 
@@ -92,8 +94,21 @@ namespace reflifc
 
         ifc::ExprSort sort() const { return index_.sort(); }
 
+        auto operator<=>(Expression const& other) const = default;
+
     private:
+        friend std::hash<Expression>;
+
         ifc::File const* ifc_;
         ifc::ExprIndex index_;
     };
 }
+
+template<>
+struct std::hash<reflifc::Expression>
+{
+    size_t operator()(reflifc::Expression const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.index_);
+    }
+};

--- a/lib/reflifc/include/reflifc/Expression.h
+++ b/lib/reflifc/include/reflifc/Expression.h
@@ -107,7 +107,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::Expression>
 {
-    size_t operator()(reflifc::Expression const& object) const noexcept
+    size_t operator()(reflifc::Expression object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.index_);
     }

--- a/lib/reflifc/include/reflifc/HashCombine.h
+++ b/lib/reflifc/include/reflifc/HashCombine.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <functional>
+
+namespace reflifc
+{
+	template<typename... Args>
+	size_t hash_combine(size_t seed, Args const&... args) noexcept
+	{
+		// Implementation inspired from Boost.
+		auto hash_combine_single = [&seed]<typename Arg>(Arg const& arg)
+		{
+			seed ^= std::hash<Arg>{}(arg) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+		};
+
+		(hash_combine_single(args), ...);
+
+		return seed;
+	}
+}

--- a/lib/reflifc/include/reflifc/Literal.h
+++ b/lib/reflifc/include/reflifc/Literal.h
@@ -38,7 +38,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::Literal>
 {
-    size_t operator()(reflifc::Literal const& object) const noexcept
+    size_t operator()(reflifc::Literal object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.index_);
     }

--- a/lib/reflifc/include/reflifc/Literal.h
+++ b/lib/reflifc/include/reflifc/Literal.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "HashCombine.h"
+
 #include <ifc/FileFwd.h>
 #include <ifc/Literal.h>
 
@@ -23,8 +25,21 @@ namespace reflifc
 
         ifc::LiteralSort sort() const { return index_.sort(); }
 
+        auto operator<=>(Literal const& other) const = default;
+
     private:
+        friend std::hash<Literal>;
+
         ifc::File const* ifc_;
         ifc::LitIndex index_;
     };
 }
+
+template<>
+struct std::hash<reflifc::Literal>
+{
+    size_t operator()(reflifc::Literal const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.index_);
+    }
+};

--- a/lib/reflifc/include/reflifc/Module.h
+++ b/lib/reflifc/include/reflifc/Module.h
@@ -119,7 +119,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::ModuleReference>
 {
-    size_t operator()(reflifc::ModuleReference const& object) const noexcept
+    size_t operator()(reflifc::ModuleReference object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.module_reference_);
     }
@@ -128,7 +128,7 @@ struct std::hash<reflifc::ModuleReference>
 template<>
 struct std::hash<reflifc::UnitDescription>
 {
-    size_t operator()(reflifc::UnitDescription const& object) const noexcept
+    size_t operator()(reflifc::UnitDescription object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.unit_);
     }
@@ -137,7 +137,7 @@ struct std::hash<reflifc::UnitDescription>
 template<>
 struct std::hash<reflifc::Module>
 {
-    size_t operator()(reflifc::Module const& object) const noexcept
+    size_t operator()(reflifc::Module object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_);
     }

--- a/lib/reflifc/include/reflifc/Module.h
+++ b/lib/reflifc/include/reflifc/Module.h
@@ -2,6 +2,8 @@
 
 #include "decl/Scope.h"
 #include "decl/ScopeDeclaration.h"
+#include "HashCombine.h"
+
 #include "ifc/Module.h"
 #include "ifc/Environment.h"
 
@@ -22,6 +24,8 @@ namespace reflifc
             return get_string_or_null(module_reference_->partition);
         }
 
+        auto operator<=>(ModuleReference const& other) const = default;
+
     private:
         const char* get_string_or_null(ifc::TextOffset text) const {
             if (ifc::is_null(text)) {
@@ -29,6 +33,8 @@ namespace reflifc
             }
             return ifc_->get_string(text);
         }
+
+        friend std::hash<ModuleReference>;
 
         ifc::ModuleReference const* module_reference_;
         ifc::File const* ifc_;
@@ -46,7 +52,11 @@ namespace reflifc
 
         const char* name() const { return ifc_->get_string(ifc::TextOffset{unit_.index}); }
 
+        auto operator<=>(UnitDescription const& other) const = default;
+
     private:
+        friend std::hash<UnitDescription>;
+
         ifc::UnitIndex unit_;
         ifc::File const* ifc_;
     };
@@ -97,7 +107,38 @@ namespace reflifc
             return { ifc_, ifc_->header().unit };
         }
 
+        auto operator<=>(Module const& other) const = default;
+
     private:
+        friend std::hash<Module>;
+
         ifc::File const* ifc_;
     };
 }
+
+template<>
+struct std::hash<reflifc::ModuleReference>
+{
+    size_t operator()(reflifc::ModuleReference const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.module_reference_);
+    }
+};
+
+template<>
+struct std::hash<reflifc::UnitDescription>
+{
+    size_t operator()(reflifc::UnitDescription const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.unit_);
+    }
+};
+
+template<>
+struct std::hash<reflifc::Module>
+{
+    size_t operator()(reflifc::Module const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_);
+    }
+};

--- a/lib/reflifc/include/reflifc/Name.h
+++ b/lib/reflifc/include/reflifc/Name.h
@@ -85,7 +85,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::Name>
 {
-    size_t operator()(reflifc::Name const& object) const noexcept
+    size_t operator()(reflifc::Name object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.index_);
     }
@@ -94,7 +94,7 @@ struct std::hash<reflifc::Name>
 template<>
 struct std::hash<reflifc::SpecializationName>
 {
-    size_t operator()(reflifc::SpecializationName const& object) const noexcept
+    size_t operator()(reflifc::SpecializationName object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.specialization_);
     }

--- a/lib/reflifc/include/reflifc/Name.h
+++ b/lib/reflifc/include/reflifc/Name.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "HashCombine.h"
+
 #include <ifc/FileFwd.h>
 #include <ifc/Name.h>
 
@@ -39,13 +41,11 @@ namespace reflifc
 
         ifc::NameSort sort() const { return index_.sort(); }
 
-        bool operator==(Name other) const
-        {
-            assert(ifc_ == other.ifc_);
-            return index_ == other.index_;
-        }
+        auto operator<=>(Name const& other) const = default;
 
     private:
+        friend std::hash<Name>;
+
         ifc::File const* ifc_;
         ifc::NameIndex index_;
     };
@@ -61,7 +61,11 @@ namespace reflifc
         Name                primary()               const;
         TupleExpressionView template_arguments()    const;
 
+        auto operator<=>(SpecializationName const& other) const = default;
+
     private:
+        friend std::hash<SpecializationName>;
+
         ifc::File const* ifc_;
         ifc::SpecializationName const* specialization_;
     };
@@ -77,3 +81,21 @@ namespace reflifc
         return is_identifier(declaration.name(), s);
     }
 }
+
+template<>
+struct std::hash<reflifc::Name>
+{
+    size_t operator()(reflifc::Name const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.index_);
+    }
+};
+
+template<>
+struct std::hash<reflifc::SpecializationName>
+{
+    size_t operator()(reflifc::SpecializationName const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.specialization_);
+    }
+};

--- a/lib/reflifc/include/reflifc/StringLiteral.h
+++ b/lib/reflifc/include/reflifc/StringLiteral.h
@@ -30,7 +30,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::StringLiteral>
 {
-    size_t operator()(reflifc::StringLiteral const& object) const noexcept
+    size_t operator()(reflifc::StringLiteral object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.literal_.start, object.literal_.length, object.literal_.suffix);
     }

--- a/lib/reflifc/include/reflifc/StringLiteral.h
+++ b/lib/reflifc/include/reflifc/StringLiteral.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "HashCombine.h"
+
 #include <ifc/FileFwd.h>
 #include <ifc/Expression.h>
 
@@ -15,8 +17,21 @@ namespace reflifc
 
         std::string_view value() const;
 
+        auto operator<=>(StringLiteral const& other) const = default;
+
     private:
+        friend std::hash<StringLiteral>;
+
         ifc::File const* ifc_;
         ifc::StringLiteral literal_;
     };
 }
+
+template<>
+struct std::hash<reflifc::StringLiteral>
+{
+    size_t operator()(reflifc::StringLiteral const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.literal_.start, object.literal_.length, object.literal_.suffix);
+    }
+};

--- a/lib/reflifc/include/reflifc/Syntax.h
+++ b/lib/reflifc/include/reflifc/Syntax.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "HashCombine.h"
+
 #include <ifc/SyntaxTreeFwd.h>
 #include <ifc/FileFwd.h>
 
@@ -29,8 +31,21 @@ namespace reflifc
         TypeTraitIntrinsicSyntax    as_type_trait_intrinsic()   const;
         Expression                  requires_clause_condition() const;
 
+        auto operator<=>(Syntax const& other) const = default;
+
     private:
+        friend std::hash<Syntax>;
+
         ifc::File const* ifc_;
         ifc::SyntaxIndex index_;
     };
 }
+
+template<>
+struct std::hash<reflifc::Syntax>
+{
+    size_t operator()(reflifc::Syntax const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.index_);
+    }
+};

--- a/lib/reflifc/include/reflifc/Syntax.h
+++ b/lib/reflifc/include/reflifc/Syntax.h
@@ -44,7 +44,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::Syntax>
 {
-    size_t operator()(reflifc::Syntax const& object) const noexcept
+    size_t operator()(reflifc::Syntax object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.index_);
     }

--- a/lib/reflifc/include/reflifc/TemplateId.h
+++ b/lib/reflifc/include/reflifc/TemplateId.h
@@ -58,7 +58,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::TemplateId>
 {
-    size_t operator()(reflifc::TemplateId const& object) const noexcept
+    size_t operator()(reflifc::TemplateId object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.template_id_);
     }
@@ -67,7 +67,7 @@ struct std::hash<reflifc::TemplateId>
 template<>
 struct std::hash<reflifc::TemplateReference>
 {
-    size_t operator()(reflifc::TemplateReference const& object) const noexcept
+    size_t operator()(reflifc::TemplateReference object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.template_ref_);
     }

--- a/lib/reflifc/include/reflifc/TemplateId.h
+++ b/lib/reflifc/include/reflifc/TemplateId.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "HashCombine.h"
+
 #include <ifc/FileFwd.h>
 #include <ifc/ExpressionFwd.h>
 
@@ -22,7 +24,11 @@ namespace reflifc
 
         TupleExpressionView arguments() const;
 
+        auto operator<=>(TemplateId const& other) const = default;
+
     private:
+        friend std::hash<TemplateId>;
+
         ifc::File const* ifc_;
         ifc::TemplateId const* template_id_;
     };
@@ -39,8 +45,30 @@ namespace reflifc
         Name                member_name()   const;
         TupleExpressionView arguments()     const;
 
+        auto operator<=>(TemplateReference const& other) const = default;
+
     private:
+        friend std::hash<TemplateReference>;
+
         ifc::File const* ifc_;
         ifc::TemplateReference const* template_ref_;
     };
 }
+
+template<>
+struct std::hash<reflifc::TemplateId>
+{
+    size_t operator()(reflifc::TemplateId const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.template_id_);
+    }
+};
+
+template<>
+struct std::hash<reflifc::TemplateReference>
+{
+    size_t operator()(reflifc::TemplateReference const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.template_ref_);
+    }
+};

--- a/lib/reflifc/include/reflifc/Type.h
+++ b/lib/reflifc/include/reflifc/Type.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "HashCombine.h"
+
 #include <ifc/FileFwd.h>
 #include <ifc/TypeFwd.h>
 
@@ -85,8 +87,21 @@ namespace reflifc
 
         ifc::TypeSort sort() const { return index_.sort(); }
 
+        auto operator<=>(Type const& other) const = default;
+
     private:
+        friend std::hash<Type>;
+
         ifc::File const* ifc_;
         ifc::TypeIndex index_;
     };
 }
+
+template<>
+struct std::hash<reflifc::Type>
+{
+    size_t operator()(reflifc::Type const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.index_);
+    }
+};

--- a/lib/reflifc/include/reflifc/Type.h
+++ b/lib/reflifc/include/reflifc/Type.h
@@ -100,7 +100,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::Type>
 {
-    size_t operator()(reflifc::Type const& object) const noexcept
+    size_t operator()(reflifc::Type object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.index_);
     }

--- a/lib/reflifc/include/reflifc/Word.h
+++ b/lib/reflifc/include/reflifc/Word.h
@@ -31,7 +31,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::Word>
 {
-    size_t operator()(reflifc::Word const& word) const noexcept
+    size_t operator()(reflifc::Word word) const noexcept
     {
         return reflifc::hash_combine(0, word.ifc_, word.word_);
     }

--- a/lib/reflifc/include/reflifc/Word.h
+++ b/lib/reflifc/include/reflifc/Word.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "HashCombine.h"
+
 #include <ifc/FileFwd.h>
 #include <ifc/WordFwd.h>
 
@@ -16,8 +18,21 @@ namespace reflifc
         bool        is_identifier() const;
         char const* as_identifier() const;
 
+        auto operator<=>(Word const& other) const = default;
+
     private:
+        friend std::hash<Word>;
+
         ifc::File const* ifc_;
         ifc::Word const* word_;
     };
 }
+
+template<>
+struct std::hash<reflifc::Word>
+{
+    size_t operator()(reflifc::Word const& word) const noexcept
+    {
+        return reflifc::hash_combine(0, word.ifc_, word.word_);
+    }
+};

--- a/lib/reflifc/include/reflifc/decl/AliasDeclaration.h
+++ b/lib/reflifc/include/reflifc/decl/AliasDeclaration.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "reflifc/HashCombine.h"
+
 #include <ifc/DeclarationFwd.h>
 #include <ifc/FileFwd.h>
 
@@ -21,8 +23,21 @@ namespace reflifc
         Declaration home_scope()const;
         ifc::Access access()    const;
 
+        auto operator<=>(AliasDeclaration const& other) const = default;
+
     private:
+        friend std::hash<AliasDeclaration>;
+
         ifc::File const* ifc_;
         ifc::AliasDeclaration const* alias_;
     };
 }
+
+template<>
+struct std::hash<reflifc::AliasDeclaration>
+{
+    size_t operator()(reflifc::AliasDeclaration const& alias) const noexcept
+    {
+        return reflifc::hash_combine(0, alias.ifc_, alias.alias_);
+    }
+};

--- a/lib/reflifc/include/reflifc/decl/AliasDeclaration.h
+++ b/lib/reflifc/include/reflifc/decl/AliasDeclaration.h
@@ -25,7 +25,7 @@ namespace reflifc
 
         ifc::File const* containing_file() const { return ifc_; }
 
-        auto operator<=>(AliasDeclaration other) const = default;
+        auto operator<=>(AliasDeclaration const& other) const = default;
 
     private:
         friend std::hash<AliasDeclaration>;

--- a/lib/reflifc/include/reflifc/decl/ClassOrStruct.h
+++ b/lib/reflifc/include/reflifc/decl/ClassOrStruct.h
@@ -44,7 +44,7 @@ namespace reflifc
 
         ifc::File const* containing_file() const { return ifc_; }
 
-        auto operator<=>(ClassOrStruct other) const = default;
+        auto operator<=>(ClassOrStruct const& other) const = default;
 
     private:
         friend std::hash<ClassOrStruct>;

--- a/lib/reflifc/include/reflifc/decl/ClassOrStruct.h
+++ b/lib/reflifc/include/reflifc/decl/ClassOrStruct.h
@@ -6,6 +6,7 @@
 #include "reflifc/type/Base.h"
 #include "reflifc/TupleView.h"
 #include "reflifc/Type.h"
+#include "reflifc/HashCombine.h"
 
 #include <ifc/File.h>
 #include <ifc/Declaration.h>
@@ -41,7 +42,11 @@ namespace reflifc
 
         Declaration home_scope() const;
 
+        auto operator<=>(ClassOrStruct const& other) const = default;
+
     private:
+        friend std::hash<ClassOrStruct>;
+
         ifc::File const* ifc_;
         ifc::ScopeDeclaration const* scope_;
     };
@@ -60,3 +65,12 @@ namespace reflifc
             | std::views::transform(&Declaration::as_variable);
     }
 }
+
+template<>
+struct std::hash<reflifc::ClassOrStruct>
+{
+    size_t operator()(reflifc::ClassOrStruct const& class_or_struct) const noexcept
+    {
+        return reflifc::hash_combine(0, class_or_struct.ifc_, class_or_struct.scope_);
+    }
+};

--- a/lib/reflifc/include/reflifc/decl/Concept.h
+++ b/lib/reflifc/include/reflifc/decl/Concept.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "reflifc/HashCombine.h"
+
 #include <ifc/DeclarationFwd.h>
 #include <ifc/FileFwd.h>
 
@@ -22,8 +24,21 @@ namespace reflifc
         Chart       chart()         const;
         Declaration home_scope()    const;
 
+        auto operator<=>(Concept const& other) const = default;
+
     private:
+        friend std::hash<Concept>;
+
         ifc::File const* ifc_;
         ifc::Concept const* c_;
     };
 }
+
+template<>
+struct std::hash<reflifc::Concept>
+{
+    size_t operator()(reflifc::Concept const& concept_) const noexcept
+    {
+        return reflifc::hash_combine(0, concept_.ifc_, concept_.c_);
+    }
+};

--- a/lib/reflifc/include/reflifc/decl/Concept.h
+++ b/lib/reflifc/include/reflifc/decl/Concept.h
@@ -26,7 +26,7 @@ namespace reflifc
 
         ifc::File const* containing_file() const { return ifc_; }
         
-        auto operator<=>(Concept other) const = default;
+        auto operator<=>(Concept const& other) const = default;
 
     private:
         friend std::hash<Concept>;

--- a/lib/reflifc/include/reflifc/decl/DeclarationReference.h
+++ b/lib/reflifc/include/reflifc/decl/DeclarationReference.h
@@ -2,6 +2,7 @@
 
 #include "reflifc/Declaration.h"
 #include "reflifc/Module.h"
+#include "reflifc/HashCombine.h"
 
 #include "ifc/FileFwd.h"
 #include "ifc/DeclarationFwd.h"
@@ -20,8 +21,21 @@ namespace reflifc
         reflifc::ModuleReference module_reference() const;
         reflifc::Declaration referenced_declaration(ifc::Environment& environment) const;
 
+        auto operator<=>(DeclarationReference const& other) const = default;
+
     private:
+        friend std::hash<DeclarationReference>;
+
         ifc::File const* ifc_;
         ifc::DeclReference const* decl_reference_;
 	};
 }
+
+template<>
+struct std::hash<reflifc::DeclarationReference>
+{
+    size_t operator()(reflifc::DeclarationReference const& decl_ref) const noexcept
+    {
+        return reflifc::hash_combine(0, decl_ref.ifc_, decl_ref.decl_reference_);
+    }
+};

--- a/lib/reflifc/include/reflifc/decl/DeclarationReference.h
+++ b/lib/reflifc/include/reflifc/decl/DeclarationReference.h
@@ -23,7 +23,7 @@ namespace reflifc
 
         ifc::File const* containing_file() const { return ifc_; }
 
-        auto operator<=>(DeclarationReference other) const = default;
+        auto operator<=>(DeclarationReference const& other) const = default;
 
     private:
         friend std::hash<DeclarationReference>;

--- a/lib/reflifc/include/reflifc/decl/Enumeration.h
+++ b/lib/reflifc/include/reflifc/decl/Enumeration.h
@@ -3,6 +3,7 @@
 #include "Enumerator.h"
 
 #include "reflifc/ViewOf.h"
+#include "reflifc/HashCombine.h"
 
 #include <ifc/Declaration.h>
 #include <ifc/File.h>
@@ -40,7 +41,11 @@ namespace reflifc
 
         ifc::Sequence enumerators_sequence() const { return enum_->initializer; }
 
+        auto operator<=>(Enumeration const& other) const = default;
+
     private:
+        friend std::hash<Enumeration>;
+
         ifc::File const* ifc_;
         ifc::Enumeration const* enum_;
     };
@@ -48,3 +53,12 @@ namespace reflifc
     std::optional<Enumerator> find_enumerator_by_value(Enumeration, std::uint32_t value);
     std::optional<Enumerator> find_enumerator_by_value(Enumeration, std::span<std::byte const> value);
 }
+
+template<>
+struct std::hash<reflifc::Enumeration>
+{
+    size_t operator()(reflifc::Enumeration const& enumeration) const noexcept
+    {
+        return reflifc::hash_combine(0, enumeration.ifc_, enumeration.enum_);
+    }
+};

--- a/lib/reflifc/include/reflifc/decl/Enumeration.h
+++ b/lib/reflifc/include/reflifc/decl/Enumeration.h
@@ -43,7 +43,7 @@ namespace reflifc
 
         ifc::File const* containing_file() const { return ifc_; }
 
-        auto operator<=>(Enumeration other) const = default;
+        auto operator<=>(Enumeration const& other) const = default;
 
     private:
         friend std::hash<Enumeration>;

--- a/lib/reflifc/include/reflifc/decl/Enumerator.h
+++ b/lib/reflifc/include/reflifc/decl/Enumerator.h
@@ -22,7 +22,7 @@ namespace reflifc
 
         ifc::File const* containing_file() const { return ifc_; }
 
-        auto operator<=>(Enumerator other) const = default;
+        auto operator<=>(Enumerator const& other) const = default;
 
     private:
         friend std::hash<Enumerator>;

--- a/lib/reflifc/include/reflifc/decl/Enumerator.h
+++ b/lib/reflifc/include/reflifc/decl/Enumerator.h
@@ -2,6 +2,7 @@
 
 #include "reflifc/Expression.h"
 #include "reflifc/Literal.h"
+#include "reflifc/HashCombine.h"
 
 #include <ifc/DeclarationFwd.h>
 
@@ -19,7 +20,11 @@ namespace reflifc
 
         Expression value() const;
 
+        auto operator<=>(Enumerator const& other) const = default;
+
     private:
+        friend std::hash<Enumerator>;
+
         ifc::File const* ifc_;
         ifc::Enumerator const* enumerator_;
     };
@@ -29,3 +34,12 @@ namespace reflifc
         return enumerator.value().as_literal().int_value();
     }
 }
+
+template<>
+struct std::hash<reflifc::Enumerator>
+{
+    size_t operator()(reflifc::Enumerator const& enumerator) const noexcept
+    {
+        return reflifc::hash_combine(0, enumerator.ifc_, enumerator.enumerator_);
+    }
+};

--- a/lib/reflifc/include/reflifc/decl/Field.h
+++ b/lib/reflifc/include/reflifc/decl/Field.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "reflifc/HashCombine.h"
+
 #include <ifc/DeclarationFwd.h>
 #include <ifc/FileFwd.h>
 
@@ -28,8 +30,21 @@ namespace reflifc
         bool has_initializer() const;
         Expression initializer() const;
 
+        auto operator<=>(Field const& other) const = default;
+
     private:
+        friend std::hash<Field>;
+
         ifc::File const* ifc_;
         ifc::FieldDeclaration const* field_;
     };
 }
+
+template<>
+struct std::hash<reflifc::Field>
+{
+    size_t operator()(reflifc::Field const& field) const noexcept
+    {
+        return reflifc::hash_combine(0, field.ifc_, field.field_);
+    }
+};

--- a/lib/reflifc/include/reflifc/decl/Field.h
+++ b/lib/reflifc/include/reflifc/decl/Field.h
@@ -32,7 +32,7 @@ namespace reflifc
 
         ifc::File const* containing_file() const { return ifc_; }
 
-        auto operator<=>(Field other) const = default;
+        auto operator<=>(Field const& other) const = default;
 
     private:
         friend std::hash<Field>;

--- a/lib/reflifc/include/reflifc/decl/Function.h
+++ b/lib/reflifc/include/reflifc/decl/Function.h
@@ -33,7 +33,7 @@ namespace reflifc
 
         ifc::File const* containing_file() const { return ifc_; }
 
-        auto operator<=>(Function other) const = default;
+        auto operator<=>(Function const& other) const = default;
 
     private:
         friend std::hash<Function>;
@@ -58,7 +58,7 @@ namespace reflifc
 
         ifc::File const* containing_file() const { return ifc_; }
 
-        auto operator<=>(Method other) const = default;
+        auto operator<=>(Method const& other) const = default;
 
     private:
         friend std::hash<Method>;
@@ -86,7 +86,7 @@ namespace reflifc
 
         ifc::File const* containing_file() const { return ifc_; }
 
-        auto operator<=>(Constructor other) const = default;
+        auto operator<=>(Constructor const& other) const = default;
 
     private:
         ifc::TorType const& tor_type() const;
@@ -111,7 +111,7 @@ namespace reflifc
 
         ifc::File const* containing_file() const { return ifc_; }
 
-        auto operator<=>(Destructor other) const = default;
+        auto operator<=>(Destructor const& other) const = default;
 
     private:
         friend std::hash<Destructor>;

--- a/lib/reflifc/include/reflifc/decl/Function.h
+++ b/lib/reflifc/include/reflifc/decl/Function.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "reflifc/Name.h"
+#include "reflifc/HashCombine.h"
 
 #include <ifc/DeclarationFwd.h>
 #include <ifc/FileFwd.h>
@@ -30,7 +31,11 @@ namespace reflifc
 
         ifc::Access access() const;
 
+        auto operator<=>(Function const& other) const = default;
+
     private:
+        friend std::hash<Function>;
+
         ifc::File const* ifc_;
         ifc::FunctionDeclaration const* func_;
     };
@@ -49,7 +54,11 @@ namespace reflifc
 
         ifc::Access access() const;
 
+        auto operator<=>(Method const& other) const = default;
+
     private:
+        friend std::hash<Method>;
+
         ifc::File const* ifc_;
         ifc::MethodDeclaration const* method_;
     };
@@ -71,10 +80,14 @@ namespace reflifc
         ifc::NoexceptSpecification  eh_spec()       const;
         ifc::CallingConvention      convention()    const;
 
+        auto operator<=>(Constructor const& other) const = default;
+
     private:
         ifc::TorType const& tor_type() const;
 
     private:
+        friend std::hash<Constructor>;
+
         ifc::File const* ifc_;
         ifc::Constructor const* ctor_;
     };
@@ -90,8 +103,48 @@ namespace reflifc
         ifc::Access access() const;
         Declaration home_scope() const;
 
+        auto operator<=>(Destructor const& other) const = default;
+
     private:
+        friend std::hash<Destructor>;
+
         ifc::File const* ifc_;
         ifc::Destructor const* dtor_;
     };
 }
+
+template<>
+struct std::hash<reflifc::Function>
+{
+    size_t operator()(reflifc::Function const& func) const noexcept
+    {
+        return reflifc::hash_combine(0, func.ifc_, func.func_);
+    }
+};
+
+template<>
+struct std::hash<reflifc::Method>
+{
+    size_t operator()(reflifc::Method const& method) const noexcept
+    {
+        return reflifc::hash_combine(0, method.ifc_, method.method_);
+    }
+};
+
+template<>
+struct std::hash<reflifc::Constructor>
+{
+    size_t operator()(reflifc::Constructor const& constructor) const noexcept
+    {
+        return reflifc::hash_combine(0, constructor.ifc_, constructor.ctor_);
+    }
+};
+
+template<>
+struct std::hash<reflifc::Destructor>
+{
+    size_t operator()(reflifc::Destructor const& destructor) const noexcept
+    {
+        return reflifc::hash_combine(0, destructor.ifc_, destructor.dtor_);
+    }
+};

--- a/lib/reflifc/include/reflifc/decl/Intrinsic.h
+++ b/lib/reflifc/include/reflifc/decl/Intrinsic.h
@@ -2,6 +2,7 @@
 
 #include "reflifc/Declaration.h"
 #include "reflifc/Type.h"
+#include "reflifc/HashCombine.h"
 
 #include <ifc/Declaration.h>
 #include <ifc/File.h>
@@ -20,8 +21,21 @@ namespace reflifc
         Type        type()          const { return { ifc_, intrinsic_->type }; }
         Declaration home_scope()    const { return { ifc_, intrinsic_->home_scope }; }
 
+        auto operator<=>(IntrinsicDeclaration const& other) const = default;
+
     private:
+        friend std::hash<IntrinsicDeclaration>;
+
         ifc::File const* ifc_;
         ifc::IntrinsicDeclaration const* intrinsic_;
     };
 }
+
+template<>
+struct std::hash<reflifc::IntrinsicDeclaration>
+{
+    size_t operator()(reflifc::IntrinsicDeclaration const& intrinsic) const noexcept
+    {
+        return reflifc::hash_combine(0, intrinsic.ifc_, intrinsic.intrinsic_);
+    }
+};

--- a/lib/reflifc/include/reflifc/decl/Intrinsic.h
+++ b/lib/reflifc/include/reflifc/decl/Intrinsic.h
@@ -23,7 +23,7 @@ namespace reflifc
 
         ifc::File const* containing_file() const { return ifc_; }
 
-        auto operator<=>(IntrinsicDeclaration other) const = default;
+        auto operator<=>(IntrinsicDeclaration const& other) const = default;
 
     private:
         friend std::hash<IntrinsicDeclaration>;

--- a/lib/reflifc/include/reflifc/decl/Namespace.h
+++ b/lib/reflifc/include/reflifc/decl/Namespace.h
@@ -23,9 +23,9 @@ namespace reflifc
 
         bool is_inline() const { return ifc::is_inline(*scope_); }
 
-        ifc::File const* containing_file() const { return &ifc_; }
+        ifc::File const* containing_file() const { return ifc_; }
 
-        auto operator<=>(Namespace other) const = default;
+        auto operator<=>(Namespace const& other) const = default;
 
     private:
         friend std::hash<Namespace>;

--- a/lib/reflifc/include/reflifc/decl/Namespace.h
+++ b/lib/reflifc/include/reflifc/decl/Namespace.h
@@ -3,6 +3,7 @@
 #include "Scope.h"
 
 #include "reflifc/Name.h"
+#include "reflifc/HashCombine.h"
 
 #include <ifc/File.h>
 #include <ifc/Declaration.h>
@@ -13,17 +14,30 @@ namespace reflifc
     {
         Namespace(ifc::File const* ifc, ifc::ScopeDeclaration const& scope)
             : ifc_(ifc)
-            , scope_(scope)
+            , scope_(&scope)
         {
         }
 
-        Name  name()  const { return { ifc_, scope_.name }; }
-        Scope scope() const { return { ifc_, scope_.initializer }; }
+        Name  name()  const { return { ifc_, scope_->name }; }
+        Scope scope() const { return { ifc_, scope_->initializer }; }
 
-        bool is_inline() const { return ifc::is_inline(scope_); }
+        bool is_inline() const { return ifc::is_inline(*scope_); }
+
+        auto operator<=>(Namespace const& other) const = default;
 
     private:
+        friend std::hash<Namespace>;
+
         ifc::File const* ifc_;
-        ifc::ScopeDeclaration const& scope_;
+        ifc::ScopeDeclaration const* scope_;
     };
 }
+
+template<>
+struct std::hash<reflifc::Namespace>
+{
+    size_t operator()(reflifc::Namespace const& namespace_) const noexcept
+    {
+        return reflifc::hash_combine(0, namespace_.ifc_, namespace_.scope_);
+    }
+};

--- a/lib/reflifc/include/reflifc/decl/Parameter.h
+++ b/lib/reflifc/include/reflifc/decl/Parameter.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "reflifc/HashCombine.h"
+
 #include <ifc/Declaration.h>
 #include <ifc/FileFwd.h>
 
@@ -25,8 +27,21 @@ namespace reflifc
         ifc::ParameterPosition position() const { return param_->position; }
         ifc::ParameterLevel level() const { return param_->level; }
 
+        auto operator<=>(Parameter const& other) const = default;
+
     private:
+        friend std::hash<Parameter>;
+
         ifc::File const* ifc_;
         ifc::ParameterDeclaration const* param_;
     };
 }
+
+template<>
+struct std::hash<reflifc::Parameter>
+{
+    size_t operator()(reflifc::Parameter const& parameter) const noexcept
+    {
+        return reflifc::hash_combine(0, parameter.ifc_, parameter.param_);
+    }
+};

--- a/lib/reflifc/include/reflifc/decl/Parameter.h
+++ b/lib/reflifc/include/reflifc/decl/Parameter.h
@@ -29,7 +29,7 @@ namespace reflifc
 
         ifc::File const* containing_file() const { return ifc_; }
 
-        auto operator<=>(Parameter other) const = default;
+        auto operator<=>(Parameter const& other) const = default;
 
     private:
         friend std::hash<Parameter>;

--- a/lib/reflifc/include/reflifc/decl/Scope.h
+++ b/lib/reflifc/include/reflifc/decl/Scope.h
@@ -26,7 +26,7 @@ namespace reflifc
 
         ifc::File const* containing_file() const { return ifc_; }
 
-        auto operator<=>(Scope other) const = default;
+        auto operator<=>(Scope const& other) const = default;
         
     private:
         friend std::hash<Scope>;

--- a/lib/reflifc/include/reflifc/decl/Scope.h
+++ b/lib/reflifc/include/reflifc/decl/Scope.h
@@ -2,6 +2,7 @@
 
 #include "reflifc/Declaration.h"
 #include "reflifc/ViewOf.h"
+#include "reflifc/HashCombine.h"
 
 #include <ifc/File.h>
 #include <ifc/Declaration.h>
@@ -23,8 +24,21 @@ namespace reflifc
                 | std::views::transform([ifc = ifc_] (ifc::Declaration decl) { return Declaration(ifc, decl.index); });
         }
 
+        auto operator<=>(Scope const& other) const = default;
+        
     private:
+        friend std::hash<Scope>;
+
         ifc::File const* ifc_;
         ifc::ScopeIndex scope_;
     };
 }
+
+template<>
+struct std::hash<reflifc::Scope>
+{
+    size_t operator()(reflifc::Scope const& scope) const noexcept
+    {
+        return reflifc::hash_combine(0, scope.ifc_, static_cast<uint32_t>(scope.scope_));
+    }
+};

--- a/lib/reflifc/include/reflifc/decl/ScopeDeclaration.h
+++ b/lib/reflifc/include/reflifc/decl/ScopeDeclaration.h
@@ -35,7 +35,7 @@ namespace reflifc
 
         ifc::File const* containing_file() const { return ifc_; }
 
-        auto operator<=>(ScopeDeclaration other) const = default;
+        auto operator<=>(ScopeDeclaration const& other) const = default;
 
     private:
         friend std::hash<ScopeDeclaration>;

--- a/lib/reflifc/include/reflifc/decl/ScopeDeclaration.h
+++ b/lib/reflifc/include/reflifc/decl/ScopeDeclaration.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "reflifc/HashCombine.h"
+
 #include <ifc/FileFwd.h>
 #include <ifc/DeclarationFwd.h>
 #include <ifc/TypeFwd.h>
@@ -31,8 +33,21 @@ namespace reflifc
         ifc::BasicSpecifiers specifiers() const;
         ifc::TypeBasis kind() const;
 
+        auto operator<=>(ScopeDeclaration const& other) const = default;
+
     private:
+        friend std::hash<ScopeDeclaration>;
+
         ifc::File const* ifc_;
         ifc::ScopeDeclaration const* scope_;
     };
 }
+
+template<>
+struct std::hash<reflifc::ScopeDeclaration>
+{
+    size_t operator()(reflifc::ScopeDeclaration const& scope_decl) const noexcept
+    {
+        return reflifc::hash_combine(0, scope_decl.ifc_, scope_decl.scope_);
+    }
+};

--- a/lib/reflifc/include/reflifc/decl/Specialization.h
+++ b/lib/reflifc/include/reflifc/decl/Specialization.h
@@ -23,7 +23,7 @@ namespace reflifc
 
         ifc::File const* containing_file() const { return ifc_; }
 
-        auto operator<=>(SpecializationForm other) const = default;
+        auto operator<=>(SpecializationForm const& other) const = default;
 
     private:
         friend std::hash<SpecializationForm>;
@@ -50,7 +50,7 @@ namespace reflifc
 
         ifc::File const* containing_file() const { return ifc_; }
 
-        auto operator<=>(PartialSpecialization other) const = default;
+        auto operator<=>(PartialSpecialization const& other) const = default;
 
     private:
         friend std::hash<PartialSpecialization>;
@@ -73,7 +73,7 @@ namespace reflifc
 
         ifc::File const* containing_file() const { return ifc_; }
 
-        auto operator<=>(Specialization other) const = default;
+        auto operator<=>(Specialization const& other) const = default;
 
     private:
         friend std::hash<Specialization>;

--- a/lib/reflifc/include/reflifc/decl/Specialization.h
+++ b/lib/reflifc/include/reflifc/decl/Specialization.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "reflifc/HashCombine.h"
 #include "reflifc/Name.h"
 
 #include <ifc/DeclarationFwd.h>
@@ -20,7 +21,11 @@ namespace reflifc
         Declaration primary_template()  const;
         TupleExpressionView arguments() const;
 
+        auto operator<=>(SpecializationForm const& other) const = default;
+
     private:
+        friend std::hash<SpecializationForm>;
+
         ifc::File const* ifc_;
         ifc::SpecializationForm const* form_;
     };
@@ -41,7 +46,11 @@ namespace reflifc
         ifc::Access access() const;
         ifc::BasicSpecifiers specifiers() const;
 
+        auto operator<=>(PartialSpecialization const& other) const = default;
+
     private:
+        friend std::hash<PartialSpecialization>;
+
         ifc::File const* ifc_;
         ifc::PartialSpecialization const* spec_;
     };
@@ -58,8 +67,39 @@ namespace reflifc
         ifc::SpecializationSort sort() const;
         SpecializationForm form() const;
 
+        auto operator<=>(Specialization const& other) const = default;
+
     private:
+        friend std::hash<Specialization>;
+
         ifc::File const* ifc_;
         ifc::Specialization const* spec_;
     };
 }
+
+template<>
+struct std::hash<reflifc::SpecializationForm>
+{
+    size_t operator()(reflifc::SpecializationForm const& specialization) const noexcept
+    {
+        return reflifc::hash_combine(0, specialization.ifc_, specialization.form_);
+    }
+};
+
+template<>
+struct std::hash<reflifc::PartialSpecialization>
+{
+    size_t operator()(reflifc::PartialSpecialization const& specialization) const noexcept
+    {
+        return reflifc::hash_combine(0, specialization.ifc_, specialization.spec_);
+    }
+};
+
+template<>
+struct std::hash<reflifc::Specialization>
+{
+    size_t operator()(reflifc::Specialization const& specialization) const noexcept
+    {
+        return reflifc::hash_combine(0, specialization.ifc_, specialization.spec_);
+    }
+};

--- a/lib/reflifc/include/reflifc/decl/TemplateDeclaration.h
+++ b/lib/reflifc/include/reflifc/decl/TemplateDeclaration.h
@@ -28,7 +28,7 @@ namespace reflifc
 
         ifc::File const* containing_file() const { return ifc_; }
 
-        auto operator<=>(TemplateDeclaration other) const = default;
+        auto operator<=>(TemplateDeclaration const& other) const = default;
 
     private:
         friend std::hash<TemplateDeclaration>;

--- a/lib/reflifc/include/reflifc/decl/TemplateDeclaration.h
+++ b/lib/reflifc/include/reflifc/decl/TemplateDeclaration.h
@@ -1,5 +1,6 @@
 ﻿#pragma once
 
+#include "reflifc/HashCombine.h"
 #include "reflifc/Name.h"
 
 #include <ifc/DeclarationFwd.h>
@@ -25,8 +26,21 @@ namespace reflifc
         ifc::Access access() const;
         ifc::BasicSpecifiers specifiers() const;
 
+        auto operator<=>(TemplateDeclaration const& other) const = default;
+
     private:
+        friend std::hash<TemplateDeclaration>;
+
         ifc::File const* ifc_;
         ifc::TemplateDeclaration const* template_;
     };
 }
+
+template<>
+struct std::hash<reflifc::TemplateDeclaration>
+{
+    size_t operator()(reflifc::TemplateDeclaration const& template_decl) const noexcept
+    {
+        return reflifc::hash_combine(0, template_decl.ifc_, template_decl.template_);
+    }
+};

--- a/lib/reflifc/include/reflifc/decl/UsingDeclaration.h
+++ b/lib/reflifc/include/reflifc/decl/UsingDeclaration.h
@@ -22,7 +22,7 @@ namespace reflifc
 
         ifc::File const* containing_file() const { return ifc_; }
 
-        auto operator<=>(UsingDeclaration other) const = default;
+        auto operator<=>(UsingDeclaration const& other) const = default;
 
     private:
         friend std::hash<UsingDeclaration>;

--- a/lib/reflifc/include/reflifc/decl/UsingDeclaration.h
+++ b/lib/reflifc/include/reflifc/decl/UsingDeclaration.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "reflifc/HashCombine.h"
+
 #include <ifc/DeclarationFwd.h>
 #include <ifc/FileFwd.h>
 
@@ -18,8 +20,21 @@ namespace reflifc
         Declaration resolution() const;
         Declaration home_scope() const;
 
+        auto operator<=>(UsingDeclaration const& other) const = default;
+
     private:
+        friend std::hash<UsingDeclaration>;
+
         ifc::File const* ifc_;
         ifc::UsingDeclaration const* using_decl_;
     };
 }
+
+template<>
+struct std::hash<reflifc::UsingDeclaration>
+{
+    size_t operator()(reflifc::UsingDeclaration const& using_decl) const noexcept
+    {
+        return reflifc::hash_combine(0, using_decl.ifc_, using_decl.using_decl_);
+    }
+};

--- a/lib/reflifc/include/reflifc/decl/Variable.h
+++ b/lib/reflifc/include/reflifc/decl/Variable.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "reflifc/HashCombine.h"
+
 #include <ifc/DeclarationFwd.h>
 #include <ifc/FileFwd.h>
 
@@ -29,8 +31,21 @@ namespace reflifc
         bool has_initializer() const;
         Expression initializer() const;
 
+        auto operator<=>(Variable const& other) const = default;
+
     private:
+        friend std::hash<Variable>;
+
         ifc::File const* ifc_;
         ifc::VariableDeclaration const* var_;
     };
 }
+
+template<>
+struct std::hash<reflifc::Variable>
+{
+    size_t operator()(reflifc::Variable const& variable) const noexcept
+    {
+        return reflifc::hash_combine(0, variable.ifc_, variable.var_);
+    }
+};

--- a/lib/reflifc/include/reflifc/decl/Variable.h
+++ b/lib/reflifc/include/reflifc/decl/Variable.h
@@ -33,7 +33,7 @@ namespace reflifc
 
         ifc::File const* containing_file() const { return ifc_; }
 
-        auto operator<=>(Variable other) const = default;
+        auto operator<=>(Variable const& other) const = default;
 
     private:
         friend std::hash<Variable>;

--- a/lib/reflifc/include/reflifc/expr/Alignof.h
+++ b/lib/reflifc/include/reflifc/expr/Alignof.h
@@ -5,12 +5,25 @@
 #include <ifc/FileFwd.h>
 #include <ifc/ExpressionFwd.h>
 
+#include <functional>
+
 namespace reflifc
 {
     struct AlignofExpression
     {
         AlignofExpression(ifc::File const* ifc, ifc::AlignofExpression const& expr);
 
+        auto operator<=>(AlignofExpression const& other) const = default;
+
         Type operand;
     };
 }
+
+template<>
+struct std::hash<reflifc::Expression>
+{
+    size_t operator()(reflifc::Expression const& object) const noexcept
+    {
+        return std::hash<reflifc::Type>{}(object.operand);
+    }
+};

--- a/lib/reflifc/include/reflifc/expr/Alignof.h
+++ b/lib/reflifc/include/reflifc/expr/Alignof.h
@@ -22,7 +22,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::AlignofExpression>
 {
-    size_t operator()(reflifc::AlignofExpression const& object) const noexcept
+    size_t operator()(reflifc::AlignofExpression object) const noexcept
     {
         return std::hash<reflifc::Type>{}(object.operand);
     }

--- a/lib/reflifc/include/reflifc/expr/Alignof.h
+++ b/lib/reflifc/include/reflifc/expr/Alignof.h
@@ -20,9 +20,9 @@ namespace reflifc
 }
 
 template<>
-struct std::hash<reflifc::Expression>
+struct std::hash<reflifc::AlignofExpression>
 {
-    size_t operator()(reflifc::Expression const& object) const noexcept
+    size_t operator()(reflifc::AlignofExpression const& object) const noexcept
     {
         return std::hash<reflifc::Type>{}(object.operand);
     }

--- a/lib/reflifc/include/reflifc/expr/Call.h
+++ b/lib/reflifc/include/reflifc/expr/Call.h
@@ -35,7 +35,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::CallExpression>
 {
-    size_t operator()(reflifc::CallExpression const& object) const noexcept
+    size_t operator()(reflifc::CallExpression object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.expr_);
     }

--- a/lib/reflifc/include/reflifc/expr/Call.h
+++ b/lib/reflifc/include/reflifc/expr/Call.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "reflifc/HashCombine.h"
+
 #include <ifc/ExpressionFwd.h>
 #include <ifc/FileFwd.h>
 
@@ -20,8 +22,21 @@ namespace reflifc
         Expression operation() const;
         TupleExpressionView arguments() const;
 
+        auto operator<=>(CallExpression const& other) const = default;
+
     private:
+        friend std::hash<CallExpression>;
+
         ifc::File const* ifc_;
         ifc::CallExpression const* expr_;
     };
 }
+
+template<>
+struct std::hash<reflifc::CallExpression>
+{
+    size_t operator()(reflifc::CallExpression const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.expr_);
+    }
+};

--- a/lib/reflifc/include/reflifc/expr/Dyad.h
+++ b/lib/reflifc/include/reflifc/expr/Dyad.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "reflifc/HashCombine.h"
+
 #include <ifc/FileFwd.h>
 #include <ifc/Expression.h>
 
@@ -23,8 +25,21 @@ namespace reflifc
 
         Declaration resolve() const;
 
+        auto operator<=>(DyadExpression const& other) const = default;
+
     private:
+        friend std::hash<DyadExpression>;
+
         ifc::File const* ifc_;
         ifc::DyadExpression const* expr_;
     };
 }
+
+template<>
+struct std::hash<reflifc::DyadExpression>
+{
+    size_t operator()(reflifc::DyadExpression const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.expr_);
+    }
+};

--- a/lib/reflifc/include/reflifc/expr/Dyad.h
+++ b/lib/reflifc/include/reflifc/expr/Dyad.h
@@ -38,7 +38,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::DyadExpression>
 {
-    size_t operator()(reflifc::DyadExpression const& object) const noexcept
+    size_t operator()(reflifc::DyadExpression object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.expr_);
     }

--- a/lib/reflifc/include/reflifc/expr/Monad.h
+++ b/lib/reflifc/include/reflifc/expr/Monad.h
@@ -37,7 +37,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::MonadExpression>
 {
-    size_t operator()(reflifc::MonadExpression const& object) const noexcept
+    size_t operator()(reflifc::MonadExpression object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.expr_);
     }

--- a/lib/reflifc/include/reflifc/expr/Monad.h
+++ b/lib/reflifc/include/reflifc/expr/Monad.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "reflifc/HashCombine.h"
+
 #include <ifc/FileFwd.h>
 #include <ifc/Expression.h>
 
@@ -22,8 +24,21 @@ namespace reflifc
 
         Declaration resolve() const;
 
+        auto operator<=>(MonadExpression const& other) const = default;
+
     private:
+        friend std::hash<MonadExpression>;
+
         ifc::File const* ifc_;
         ifc::MonadExpression const* expr_;
     };
 }
+
+template<>
+struct std::hash<reflifc::MonadExpression>
+{
+    size_t operator()(reflifc::MonadExpression const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.expr_);
+    }
+};

--- a/lib/reflifc/include/reflifc/expr/Path.h
+++ b/lib/reflifc/include/reflifc/expr/Path.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "reflifc/HashCombine.h"
+
 #include <ifc/FileFwd.h>
 #include <ifc/ExpressionFwd.h>
 
@@ -18,8 +20,21 @@ namespace reflifc
         Expression scope() const;
         Expression member() const;
 
+        auto operator<=>(PathExpression const& other) const = default;
+
     private:
+        friend std::hash<PathExpression>;
+
         ifc::File const* ifc_;
         ifc::PathExpression const* expr_;
     };
 }
+
+template<>
+struct std::hash<reflifc::PathExpression>
+{
+    size_t operator()(reflifc::PathExpression const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.expr_);
+    }
+};

--- a/lib/reflifc/include/reflifc/expr/Path.h
+++ b/lib/reflifc/include/reflifc/expr/Path.h
@@ -33,7 +33,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::PathExpression>
 {
-    size_t operator()(reflifc::PathExpression const& object) const noexcept
+    size_t operator()(reflifc::PathExpression object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.expr_);
     }

--- a/lib/reflifc/include/reflifc/expr/ProductValueType.h
+++ b/lib/reflifc/include/reflifc/expr/ProductValueType.h
@@ -34,7 +34,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::ProductValueTypeExpression>
 {
-    size_t operator()(reflifc::ProductValueTypeExpression const& object) const noexcept
+    size_t operator()(reflifc::ProductValueTypeExpression object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.expr_);
     }

--- a/lib/reflifc/include/reflifc/expr/ProductValueType.h
+++ b/lib/reflifc/include/reflifc/expr/ProductValueType.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "reflifc/HashCombine.h"
+
 #include <ifc/FileFwd.h>
 #include <ifc/ExpressionFwd.h>
 
@@ -19,8 +21,21 @@ namespace reflifc
         Type                structure() const;
         TupleExpressionView members() const;
 
+        auto operator<=>(ProductValueTypeExpression const& other) const = default;
+
     private:
+        friend std::hash<ProductValueTypeExpression>;
+
         ifc::File const* ifc_;
         ifc::ProductValueTypeExpression const* expr_;
     };
 }
+
+template<>
+struct std::hash<reflifc::ProductValueTypeExpression>
+{
+    size_t operator()(reflifc::ProductValueTypeExpression const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.expr_);
+    }
+};

--- a/lib/reflifc/include/reflifc/expr/QualifiedName.h
+++ b/lib/reflifc/include/reflifc/expr/QualifiedName.h
@@ -37,9 +37,9 @@ namespace reflifc
 }
 
 template<>
-struct std::hash<reflifc::ProductValueTypeExpression>
+struct std::hash<reflifc::QualifiedNameExpression>
 {
-    size_t operator()(reflifc::ProductValueTypeExpression const& object) const noexcept
+    size_t operator()(reflifc::QualifiedNameExpression const& object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.expr_);
     }

--- a/lib/reflifc/include/reflifc/expr/QualifiedName.h
+++ b/lib/reflifc/include/reflifc/expr/QualifiedName.h
@@ -39,7 +39,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::QualifiedNameExpression>
 {
-    size_t operator()(reflifc::QualifiedNameExpression const& object) const noexcept
+    size_t operator()(reflifc::QualifiedNameExpression object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.expr_);
     }

--- a/lib/reflifc/include/reflifc/expr/QualifiedName.h
+++ b/lib/reflifc/include/reflifc/expr/QualifiedName.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "reflifc/HashCombine.h"
+
 #include "reflifc/Expression.h"
 #include "reflifc/ViewOf.h"
 
@@ -24,8 +26,21 @@ namespace reflifc
                 | std::views::transform([ifc = ifc_] (ifc::ExprIndex part) { return Expression(ifc, part); });
         }
 
+        auto operator<=>(QualifiedNameExpression const& other) const = default;
+
     private:
+        friend std::hash<QualifiedNameExpression>;
+
         ifc::File const* ifc_;
         ifc::QualifiedNameExpression const* expr_;
     };
 }
+
+template<>
+struct std::hash<reflifc::ProductValueTypeExpression>
+{
+    size_t operator()(reflifc::ProductValueTypeExpression const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.expr_);
+    }
+};

--- a/lib/reflifc/include/reflifc/expr/Read.h
+++ b/lib/reflifc/include/reflifc/expr/Read.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "reflifc/HashCombine.h"
+
 #include <ifc/FileFwd.h>
 #include <ifc/ExpressionFwd.h>
 
@@ -17,8 +19,21 @@ namespace reflifc
 
         Expression address() const;
 
+        auto operator<=>(ReadExpression const& other) const = default;
+
     private:
+        friend std::hash<ReadExpression>;
+
         ifc::File const* ifc_;
         ifc::ReadExpression const* expr_;
     };
 }
+
+template<>
+struct std::hash<reflifc::ReadExpression>
+{
+    size_t operator()(reflifc::ReadExpression const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.expr_);
+    }
+};

--- a/lib/reflifc/include/reflifc/expr/Read.h
+++ b/lib/reflifc/include/reflifc/expr/Read.h
@@ -32,7 +32,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::ReadExpression>
 {
-    size_t operator()(reflifc::ReadExpression const& object) const noexcept
+    size_t operator()(reflifc::ReadExpression object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.expr_);
     }

--- a/lib/reflifc/include/reflifc/expr/RequiresExpression.h
+++ b/lib/reflifc/include/reflifc/expr/RequiresExpression.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "reflifc/HashCombine.h"
+
 #include <ifc/FileFwd.h>
 #include <ifc/ExpressionFwd.h>
 
@@ -13,8 +15,21 @@ namespace reflifc
         {
         }
 
+        auto operator<=>(RequiresExpression const& other) const = default;
+
     private:
+        friend std::hash<RequiresExpression>;
+
         ifc::File const* ifc_;
         ifc::RequiresExpression const& expr_;
     };
 }
+
+template<>
+struct std::hash<reflifc::RequiresExpression>
+{
+    size_t operator()(reflifc::RequiresExpression const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.expr_);
+    }
+};

--- a/lib/reflifc/include/reflifc/expr/RequiresExpression.h
+++ b/lib/reflifc/include/reflifc/expr/RequiresExpression.h
@@ -11,7 +11,7 @@ namespace reflifc
     {
         RequiresExpression(ifc::File const* ifc, ifc::RequiresExpression const& expr)
             : ifc_(ifc)
-            , expr_(expr)
+            , expr_(&expr)
         {
         }
 
@@ -21,7 +21,7 @@ namespace reflifc
         friend std::hash<RequiresExpression>;
 
         ifc::File const* ifc_;
-        ifc::RequiresExpression const& expr_;
+        ifc::RequiresExpression const* expr_;
     };
 }
 

--- a/lib/reflifc/include/reflifc/expr/RequiresExpression.h
+++ b/lib/reflifc/include/reflifc/expr/RequiresExpression.h
@@ -28,7 +28,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::RequiresExpression>
 {
-    size_t operator()(reflifc::RequiresExpression const& object) const noexcept
+    size_t operator()(reflifc::RequiresExpression object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.expr_);
     }

--- a/lib/reflifc/include/reflifc/expr/Sizeof.h
+++ b/lib/reflifc/include/reflifc/expr/Sizeof.h
@@ -5,12 +5,25 @@
 #include <ifc/FileFwd.h>
 #include <ifc/ExpressionFwd.h>
 
+#include <functional>
+
 namespace reflifc
 {
     struct SizeofExpression
     {
         SizeofExpression(ifc::File const* ifc, ifc::SizeofExpression const& expr);
 
+        auto operator<=>(SizeofExpression const& other) const = default;
+
         Type operand;
     };
 }
+
+template<>
+struct std::hash<reflifc::SizeofExpression>
+{
+    size_t operator()(reflifc::SizeofExpression const& object) const noexcept
+    {
+        return std::hash<reflifc::Type>{}(object.operand);
+    }
+};

--- a/lib/reflifc/include/reflifc/expr/Sizeof.h
+++ b/lib/reflifc/include/reflifc/expr/Sizeof.h
@@ -22,7 +22,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::SizeofExpression>
 {
-    size_t operator()(reflifc::SizeofExpression const& object) const noexcept
+    size_t operator()(reflifc::SizeofExpression object) const noexcept
     {
         return std::hash<reflifc::Type>{}(object.operand);
     }

--- a/lib/reflifc/include/reflifc/expr/UnqualifiedId.h
+++ b/lib/reflifc/include/reflifc/expr/UnqualifiedId.h
@@ -35,7 +35,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::UnqualifiedIdExpression>
 {
-    size_t operator()(reflifc::UnqualifiedIdExpression const& object) const noexcept
+    size_t operator()(reflifc::UnqualifiedIdExpression object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.expr_);
     }

--- a/lib/reflifc/include/reflifc/expr/UnqualifiedId.h
+++ b/lib/reflifc/include/reflifc/expr/UnqualifiedId.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "reflifc/HashCombine.h"
+
 #include <ifc/FileFwd.h>
 #include <ifc/ExpressionFwd.h>
 
@@ -20,8 +22,21 @@ namespace reflifc
 
         Expression resolution() const;
 
+        auto operator<=>(UnqualifiedIdExpression const& other) const = default;
+
     private:
+        friend std::hash<UnqualifiedIdExpression>;
+
         ifc::File const* ifc_;
         ifc::UnqualifiedId const* expr_;
     };
 }
+
+template<>
+struct std::hash<reflifc::UnqualifiedIdExpression>
+{
+    size_t operator()(reflifc::UnqualifiedIdExpression const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.expr_);
+    }
+};

--- a/lib/reflifc/include/reflifc/syntax/TemplateId.h
+++ b/lib/reflifc/include/reflifc/syntax/TemplateId.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "reflifc/HashCombine.h"
+
 #include <ifc/FileFwd.h>
 #include <ifc/SyntaxTreeFwd.h>
 
@@ -19,8 +21,21 @@ namespace reflifc
         Syntax          name() const;
         TupleSyntaxView arguments() const;
 
+        auto operator<=>(TemplateIdSyntax const& other) const = default;
+
     private:
+        friend std::hash<TemplateIdSyntax>;
+
         ifc::File const* ifc_;
         ifc::TemplateIdSyntax const* syntax_;
     };
 }
+
+template<>
+struct std::hash<reflifc::TemplateIdSyntax>
+{
+    size_t operator()(reflifc::TemplateIdSyntax const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.syntax_);
+    }
+};

--- a/lib/reflifc/include/reflifc/syntax/TemplateId.h
+++ b/lib/reflifc/include/reflifc/syntax/TemplateId.h
@@ -34,7 +34,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::TemplateIdSyntax>
 {
-    size_t operator()(reflifc::TemplateIdSyntax const& object) const noexcept
+    size_t operator()(reflifc::TemplateIdSyntax object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.syntax_);
     }

--- a/lib/reflifc/include/reflifc/syntax/TypeId.h
+++ b/lib/reflifc/include/reflifc/syntax/TypeId.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "reflifc/HashCombine.h"
+
 #include <ifc/FileFwd.h>
 #include <ifc/SyntaxTreeFwd.h>
 
@@ -17,8 +19,21 @@ namespace reflifc
 
         TypeSpecifierSyntax type_specifier() const;
 
+        auto operator<=>(TypeIdSyntax const& other) const = default;
+
     private:
+        friend std::hash<TypeIdSyntax>;
+
         ifc::File const* ifc_;
         ifc::TypeIdSyntax const* syntax_;
     };
 }
+
+template<>
+struct std::hash<reflifc::TypeIdSyntax>
+{
+    size_t operator()(reflifc::TypeIdSyntax const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.syntax_);
+    }
+};

--- a/lib/reflifc/include/reflifc/syntax/TypeId.h
+++ b/lib/reflifc/include/reflifc/syntax/TypeId.h
@@ -32,7 +32,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::TypeIdSyntax>
 {
-    size_t operator()(reflifc::TypeIdSyntax const& object) const noexcept
+    size_t operator()(reflifc::TypeIdSyntax object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.syntax_);
     }

--- a/lib/reflifc/include/reflifc/syntax/TypeSpecifier.h
+++ b/lib/reflifc/include/reflifc/syntax/TypeSpecifier.h
@@ -22,6 +22,8 @@ namespace reflifc
         auto operator<=>(TypeSpecifierSyntax const& other) const = default;
 
     private:
+        friend std::hash<TypeSpecifierSyntax>;
+
         ifc::File const* ifc_;
         ifc::TypeSpecifierSeq const* syntax_;
     };

--- a/lib/reflifc/include/reflifc/syntax/TypeSpecifier.h
+++ b/lib/reflifc/include/reflifc/syntax/TypeSpecifier.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "reflifc/HashCombine.h"
+
 #include <ifc/FileFwd.h>
 #include <ifc/SyntaxTreeFwd.h>
 
@@ -17,8 +19,19 @@ namespace reflifc
 
         Syntax typename_() const;
 
+        auto operator<=>(TypeSpecifierSyntax const& other) const = default;
+
     private:
         ifc::File const* ifc_;
         ifc::TypeSpecifierSeq const* syntax_;
     };
 }
+
+template<>
+struct std::hash<reflifc::TypeSpecifierSyntax>
+{
+    size_t operator()(reflifc::TypeSpecifierSyntax const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.syntax_);
+    }
+};

--- a/lib/reflifc/include/reflifc/syntax/TypeSpecifier.h
+++ b/lib/reflifc/include/reflifc/syntax/TypeSpecifier.h
@@ -32,7 +32,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::TypeSpecifierSyntax>
 {
-    size_t operator()(reflifc::TypeSpecifierSyntax const& object) const noexcept
+    size_t operator()(reflifc::TypeSpecifierSyntax object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.syntax_);
     }

--- a/lib/reflifc/include/reflifc/syntax/TypeTraitIntrinsic.h
+++ b/lib/reflifc/include/reflifc/syntax/TypeTraitIntrinsic.h
@@ -43,7 +43,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::TypeTraitIntrinsicSyntax>
 {
-    size_t operator()(reflifc::TypeTraitIntrinsicSyntax const& object) const noexcept
+    size_t operator()(reflifc::TypeTraitIntrinsicSyntax object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.syntax_);
     }

--- a/lib/reflifc/include/reflifc/syntax/TypeTraitIntrinsic.h
+++ b/lib/reflifc/include/reflifc/syntax/TypeTraitIntrinsic.h
@@ -3,6 +3,7 @@
 #include "reflifc/ViewOf.h"
 #include "reflifc/Syntax.h"
 #include "reflifc/TupleView.h"
+#include "reflifc/HashCombine.h"
 
 #include <ifc/FileFwd.h>
 #include <ifc/SyntaxTree.h>
@@ -29,8 +30,21 @@ namespace reflifc
                 | std::views::transform([] (Syntax syntax) { return syntax.as_type_template_argument(); });
         }
 
+        auto operator<=>(TypeTraitIntrinsicSyntax const& other) const = default;
+
     private:
+        friend std::hash<TypeTraitIntrinsicSyntax>;
+
         ifc::File const* ifc_;
         ifc::TypeTraitIntrinsicSyntax const* syntax_;
     };
 }
+
+template<>
+struct std::hash<reflifc::TypeTraitIntrinsicSyntax>
+{
+    size_t operator()(reflifc::TypeTraitIntrinsicSyntax const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.syntax_);
+    }
+};

--- a/lib/reflifc/include/reflifc/type/Array.h
+++ b/lib/reflifc/include/reflifc/type/Array.h
@@ -36,7 +36,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::ArrayType>
 {
-    size_t operator()(reflifc::ArrayType const& object) const noexcept
+    size_t operator()(reflifc::ArrayType object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.array_);
     }

--- a/lib/reflifc/include/reflifc/type/Array.h
+++ b/lib/reflifc/include/reflifc/type/Array.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "reflifc/HashCombine.h"
+
 #include <ifc/FileFwd.h>
 #include <ifc/TypeFwd.h>
 
@@ -19,10 +21,23 @@ namespace reflifc
         Type        element() const;
         Expression  extent() const;
 
+        auto operator<=>(ArrayType const& other) const = default;
+
     private:
+        friend std::hash<ArrayType>;
+
         ifc::File const* ifc_;
         ifc::ArrayType const* array_;
     };
 
     std::uint32_t extent_value(ArrayType);
 }
+
+template<>
+struct std::hash<reflifc::ArrayType>
+{
+    size_t operator()(reflifc::ArrayType const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.array_);
+    }
+};

--- a/lib/reflifc/include/reflifc/type/Base.h
+++ b/lib/reflifc/include/reflifc/type/Base.h
@@ -29,7 +29,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::BaseType>
 {
-    size_t operator()(reflifc::BaseType const& object) const noexcept
+    size_t operator()(reflifc::BaseType object) const noexcept
     {
         return reflifc::hash_combine(0, object.type, static_cast<uint32_t>(object.access), static_cast<uint32_t>(object.specifiers) );
     }

--- a/lib/reflifc/include/reflifc/type/Base.h
+++ b/lib/reflifc/include/reflifc/type/Base.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "reflifc/HashCombine.h"
+
 #include <ifc/FileFwd.h>
 #include <ifc/Type.h>
 
@@ -16,8 +18,19 @@ namespace reflifc
         {
         }
 
+        auto operator<=>(BaseType const& other) const = default;
+
         Type type;
         ifc::Access access;
         ifc::BaseType::Specifiers specifiers;
     };
 }
+
+template<>
+struct std::hash<reflifc::BaseType>
+{
+    size_t operator()(reflifc::BaseType const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.type, static_cast<uint32_t>(object.access), static_cast<uint32_t>(object.specifiers) );
+    }
+};

--- a/lib/reflifc/include/reflifc/type/Expansion.h
+++ b/lib/reflifc/include/reflifc/type/Expansion.h
@@ -32,7 +32,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::ExpansionType>
 {
-    size_t operator()(reflifc::ExpansionType const& object) const noexcept
+    size_t operator()(reflifc::ExpansionType object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.expansion_);
     }

--- a/lib/reflifc/include/reflifc/type/Expansion.h
+++ b/lib/reflifc/include/reflifc/type/Expansion.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "reflifc/HashCombine.h"
+
 #include <ifc/FileFwd.h>
 #include <ifc/TypeFwd.h>
 
@@ -17,8 +19,21 @@ namespace reflifc
 
         Type pack() const;
 
+        auto operator<=>(ExpansionType const& other) const = default;
+
     private:
+        friend std::hash<ExpansionType>;
+
         ifc::File const* ifc_;
         ifc::ExpansionType const* expansion_;
     };
 }
+
+template<>
+struct std::hash<reflifc::ExpansionType>
+{
+    size_t operator()(reflifc::ExpansionType const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.expansion_);
+    }
+};

--- a/lib/reflifc/include/reflifc/type/Forall.h
+++ b/lib/reflifc/include/reflifc/type/Forall.h
@@ -34,7 +34,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::ForallType>
 {
-    size_t operator()(reflifc::ForallType const& object) const noexcept
+    size_t operator()(reflifc::ForallType object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.forall_);
     }

--- a/lib/reflifc/include/reflifc/type/Forall.h
+++ b/lib/reflifc/include/reflifc/type/Forall.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "reflifc/HashCombine.h"
+
 #include <ifc/FileFwd.h>
 #include <ifc/TypeFwd.h>
 
@@ -19,8 +21,21 @@ namespace reflifc
         Chart   chart()     const;
         Type    subject()   const;
 
+        auto operator<=>(ForallType const& other) const = default;
+
     private:
+        friend std::hash<ForallType>;
+
         ifc::File const* ifc_;
         ifc::ForallType const* forall_;
     };
 }
+
+template<>
+struct std::hash<reflifc::ForallType>
+{
+    size_t operator()(reflifc::ForallType const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.forall_);
+    }
+};

--- a/lib/reflifc/include/reflifc/type/Function.h
+++ b/lib/reflifc/include/reflifc/type/Function.h
@@ -66,7 +66,7 @@ struct std::hash<reflifc::FunctionType>
 template<>
 struct std::hash<reflifc::MethodType>
 {
-    size_t operator()(reflifc::MethodType const& object) const noexcept
+    size_t operator()(reflifc::MethodType object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.method_);
     }

--- a/lib/reflifc/include/reflifc/type/Function.h
+++ b/lib/reflifc/include/reflifc/type/Function.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "reflifc/HashCombine.h"
+
 #include <ifc/FileFwd.h>
 #include <ifc/TypeFwd.h>
 
@@ -19,7 +21,11 @@ namespace reflifc
         TupleTypeView   parameters()    const;
         Type            return_type()   const;
 
+        auto operator<=>(FunctionType const& other) const = default;
+
     private:
+        friend std::hash<FunctionType>;
+
         ifc::File const* ifc_;
         ifc::FunctionType const& function_;
     };
@@ -38,8 +44,30 @@ namespace reflifc
 
         ifc::FunctionTypeTraits traits() const;
 
+        auto operator<=>(MethodType const& other) const = default;
+
     private:
+        friend std::hash<MethodType>;
+
         ifc::File const* ifc_;
         ifc::MethodType const& method_;
     };
 }
+
+template<>
+struct std::hash<reflifc::FunctionType>
+{
+    size_t operator()(reflifc::FunctionType const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.function_);
+    }
+};
+
+template<>
+struct std::hash<reflifc::MethodType>
+{
+    size_t operator()(reflifc::MethodType const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.method_);
+    }
+};

--- a/lib/reflifc/include/reflifc/type/Function.h
+++ b/lib/reflifc/include/reflifc/type/Function.h
@@ -14,7 +14,7 @@ namespace reflifc
     {
         FunctionType(ifc::File const* ifc, ifc::FunctionType const& function)
             : ifc_(ifc)
-            , function_(function)
+            , function_(&function)
         {
         }
 
@@ -27,14 +27,14 @@ namespace reflifc
         friend std::hash<FunctionType>;
 
         ifc::File const* ifc_;
-        ifc::FunctionType const& function_;
+        ifc::FunctionType const* function_;
     };
 
     struct MethodType
     {
         MethodType(ifc::File const* ifc, ifc::MethodType const& method)
             : ifc_(ifc)
-            , method_(method)
+            , method_(&method)
         {
         }
 
@@ -50,7 +50,7 @@ namespace reflifc
         friend std::hash<MethodType>;
 
         ifc::File const* ifc_;
-        ifc::MethodType const& method_;
+        ifc::MethodType const* method_;
     };
 }
 

--- a/lib/reflifc/include/reflifc/type/Placeholder.h
+++ b/lib/reflifc/include/reflifc/type/Placeholder.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "reflifc/HashCombine.h"
+
 #include <ifc/FileFwd.h>
 #include <ifc/TypeFwd.h>
 
@@ -18,8 +20,21 @@ namespace reflifc
         ifc::TypeBasis basis() const;
         Type elaboration() const;
 
+        auto operator<=>(PlaceholderType const& other) const = default;
+
     private:
+        friend std::hash<PlaceholderType>;
+
         ifc::File const* ifc_;
         ifc::PlaceholderType const* placeholder_;
     };
 }
+
+template<>
+struct std::hash<reflifc::PlaceholderType>
+{
+    size_t operator()(reflifc::PlaceholderType const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.placeholder_);
+    }
+};

--- a/lib/reflifc/include/reflifc/type/Placeholder.h
+++ b/lib/reflifc/include/reflifc/type/Placeholder.h
@@ -33,7 +33,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::PlaceholderType>
 {
-    size_t operator()(reflifc::PlaceholderType const& object) const noexcept
+    size_t operator()(reflifc::PlaceholderType object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.placeholder_);
     }

--- a/lib/reflifc/include/reflifc/type/Pointer.h
+++ b/lib/reflifc/include/reflifc/type/Pointer.h
@@ -4,6 +4,8 @@
 
 #include <ifc/Type.h>
 
+#include <functional>
+
 namespace reflifc
 {
     struct PointerType
@@ -13,6 +15,17 @@ namespace reflifc
         {
         }
 
+        auto operator<=>(PointerType const& other) const = default;
+
         Type pointee;
     };
 }
+
+template<>
+struct std::hash<reflifc::PointerType>
+{
+    size_t operator()(reflifc::PointerType const& object) const noexcept
+    {
+        return std::hash<reflifc::Type>{}(object.pointee);
+    }
+};

--- a/lib/reflifc/include/reflifc/type/Pointer.h
+++ b/lib/reflifc/include/reflifc/type/Pointer.h
@@ -24,7 +24,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::PointerType>
 {
-    size_t operator()(reflifc::PointerType const& object) const noexcept
+    size_t operator()(reflifc::PointerType object) const noexcept
     {
         return std::hash<reflifc::Type>{}(object.pointee);
     }

--- a/lib/reflifc/include/reflifc/type/Qualified.h
+++ b/lib/reflifc/include/reflifc/type/Qualified.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "reflifc/HashCombine.h"
+
 #include <ifc/FileFwd.h>
 #include <ifc/TypeFwd.h>
 
@@ -18,8 +20,21 @@ namespace reflifc
         Type            unqualified()   const;
         ifc::Qualifiers qualifiers()    const;
 
+        auto operator<=>(QualifiedType const& other) const = default;
+
     private:
+        friend std::hash<QualifiedType>;
+
         ifc::File const* ifc_;
         ifc::QualifiedType const& qualified_;
     };
 }
+
+template<>
+struct std::hash<reflifc::QualifiedType>
+{
+    size_t operator()(reflifc::QualifiedType const& object) const noexcept
+    {
+        return reflifc::hash_combine(0, object.ifc_, object.qualified_);
+    }
+};

--- a/lib/reflifc/include/reflifc/type/Qualified.h
+++ b/lib/reflifc/include/reflifc/type/Qualified.h
@@ -33,7 +33,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::QualifiedType>
 {
-    size_t operator()(reflifc::QualifiedType const& object) const noexcept
+    size_t operator()(reflifc::QualifiedType object) const noexcept
     {
         return reflifc::hash_combine(0, object.ifc_, object.qualified_);
     }

--- a/lib/reflifc/include/reflifc/type/Qualified.h
+++ b/lib/reflifc/include/reflifc/type/Qualified.h
@@ -13,7 +13,7 @@ namespace reflifc
     {
         QualifiedType(ifc::File const* ifc, ifc::QualifiedType const& qualified)
             : ifc_(ifc),
-              qualified_(qualified)
+              qualified_(&qualified)
         {
         }
 
@@ -26,7 +26,7 @@ namespace reflifc
         friend std::hash<QualifiedType>;
 
         ifc::File const* ifc_;
-        ifc::QualifiedType const& qualified_;
+        ifc::QualifiedType const* qualified_;
     };
 }
 

--- a/lib/reflifc/include/reflifc/type/Reference.h
+++ b/lib/reflifc/include/reflifc/type/Reference.h
@@ -4,6 +4,8 @@
 
 #include <ifc/Type.h>
 
+#include <functional>
+
 namespace reflifc
 {
     struct LvalueReference
@@ -12,6 +14,8 @@ namespace reflifc
             : referee(ifc, ref.referee)
         {
         }
+
+        auto operator<=>(LvalueReference const& other) const = default;
 
         Type referee;
     };
@@ -23,7 +27,27 @@ namespace reflifc
         {
         }
 
+        auto operator<=>(RvalueReference const& other) const = default;
+
         Type referee;
     };
     
 }
+
+template<>
+struct std::hash<reflifc::LvalueReference>
+{
+    size_t operator()(reflifc::LvalueReference const& object) const noexcept
+    {
+        return std::hash<reflifc::Type>{}(object.referee);
+    }
+};
+
+template<>
+struct std::hash<reflifc::RvalueReference>
+{
+    size_t operator()(reflifc::RvalueReference const& object) const noexcept
+    {
+        return std::hash<reflifc::Type>{}(object.referee);
+    }
+};

--- a/lib/reflifc/include/reflifc/type/Reference.h
+++ b/lib/reflifc/include/reflifc/type/Reference.h
@@ -37,7 +37,7 @@ namespace reflifc
 template<>
 struct std::hash<reflifc::LvalueReference>
 {
-    size_t operator()(reflifc::LvalueReference const& object) const noexcept
+    size_t operator()(reflifc::LvalueReference object) const noexcept
     {
         return std::hash<reflifc::Type>{}(object.referee);
     }
@@ -46,7 +46,7 @@ struct std::hash<reflifc::LvalueReference>
 template<>
 struct std::hash<reflifc::RvalueReference>
 {
-    size_t operator()(reflifc::RvalueReference const& object) const noexcept
+    size_t operator()(reflifc::RvalueReference object) const noexcept
     {
         return std::hash<reflifc::Type>{}(object.referee);
     }

--- a/lib/reflifc/src/type/Function.cpp
+++ b/lib/reflifc/src/type/Function.cpp
@@ -9,31 +9,31 @@ namespace reflifc
 {
     TupleTypeView FunctionType::parameters() const
     {
-        return { ifc_, function_.source };
+        return { ifc_, function_->source };
     }
 
     Type FunctionType::return_type() const
     {
-        return { ifc_, function_.target };
+        return { ifc_, function_->target };
     }
 
     TupleTypeView MethodType::parameters() const
     {
-        return { ifc_, method_.source };
+        return { ifc_, method_->source };
     }
 
     Type MethodType::return_type() const
     {
-        return { ifc_, method_.target };
+        return { ifc_, method_->target };
     }
 
     Type MethodType::scope() const
     {
-        return { ifc_, method_.scope };
+        return { ifc_, method_->scope };
     }
 
     ifc::FunctionTypeTraits MethodType::traits() const
     {
-        return method_.traits;
+        return method_->traits;
     }
 }

--- a/lib/reflifc/src/type/Qualified.cpp
+++ b/lib/reflifc/src/type/Qualified.cpp
@@ -8,11 +8,11 @@ namespace reflifc
 {
     Type QualifiedType::unqualified() const
     {
-        return { ifc_, qualified_.unqualified };
+        return { ifc_, qualified_->unqualified };
     }
 
     ifc::Qualifiers QualifiedType::qualifiers() const
     {
-        return qualified_.qualifiers;
+        return qualified_->qualifiers;
     }
 }


### PR DESCRIPTION
Added std::hash specializations to all reflifc classes.
Added all compare operations to reflifc classes.

Please note that I branched off from the previous PR, (#28 ). Feel free to pull that one first, then I will resolve any merge conflicts if needed. All the work for this PR is in [e649da6](https://github.com/AndreyG/ifc-reader/pull/29/commits/e649da6dea584df4fa465f3ba3fa198b7729b914) and [ca5da83](https://github.com/AndreyG/ifc-reader/pull/29/commits/ca5da83a9b9695a2596bc4348801111be730bd22)