### PR TITLE
Added containing_file() to Declarations. Fixes #27

### DIFF
--- a/lib/reflifc/include/reflifc/Declaration.h
+++ b/lib/reflifc/include/reflifc/Declaration.h
@@ -118,6 +118,8 @@ namespace reflifc
             return index_ == other.index_;
         }
 
+        ifc::File const* containing_file() const { return ifc_; }
+
     private:
         ifc::File const* ifc_;
         ifc::DeclIndex index_;

--- a/lib/reflifc/include/reflifc/decl/AliasDeclaration.h
+++ b/lib/reflifc/include/reflifc/decl/AliasDeclaration.h
@@ -21,6 +21,8 @@ namespace reflifc
         Declaration home_scope()const;
         ifc::Access access()    const;
 
+        ifc::File const* containing_file() const { return ifc_; }
+
     private:
         ifc::File const* ifc_;
         ifc::AliasDeclaration const* alias_;

--- a/lib/reflifc/include/reflifc/decl/ClassOrStruct.h
+++ b/lib/reflifc/include/reflifc/decl/ClassOrStruct.h
@@ -41,6 +41,8 @@ namespace reflifc
 
         Declaration home_scope() const;
 
+        ifc::File const* containing_file() const { return ifc_; }
+
     private:
         ifc::File const* ifc_;
         ifc::ScopeDeclaration const* scope_;

--- a/lib/reflifc/include/reflifc/decl/Concept.h
+++ b/lib/reflifc/include/reflifc/decl/Concept.h
@@ -22,6 +22,8 @@ namespace reflifc
         Chart       chart()         const;
         Declaration home_scope()    const;
 
+        ifc::File const* containing_file() const { return ifc_; }
+
     private:
         ifc::File const* ifc_;
         ifc::Concept const* c_;

--- a/lib/reflifc/include/reflifc/decl/DeclarationReference.h
+++ b/lib/reflifc/include/reflifc/decl/DeclarationReference.h
@@ -20,6 +20,8 @@ namespace reflifc
         reflifc::ModuleReference module_reference() const;
         reflifc::Declaration referenced_declaration(ifc::Environment& environment) const;
 
+        ifc::File const* containing_file() const { return ifc_; }
+
     private:
         ifc::File const* ifc_;
         ifc::DeclReference const* decl_reference_;

--- a/lib/reflifc/include/reflifc/decl/Enumeration.h
+++ b/lib/reflifc/include/reflifc/decl/Enumeration.h
@@ -40,6 +40,8 @@ namespace reflifc
 
         ifc::Sequence enumerators_sequence() const { return enum_->initializer; }
 
+        ifc::File const* containing_file() const { return ifc_; }
+
     private:
         ifc::File const* ifc_;
         ifc::Enumeration const* enum_;

--- a/lib/reflifc/include/reflifc/decl/Enumerator.h
+++ b/lib/reflifc/include/reflifc/decl/Enumerator.h
@@ -19,6 +19,8 @@ namespace reflifc
 
         Expression value() const;
 
+        ifc::File const* containing_file() const { return ifc_; }
+
     private:
         ifc::File const* ifc_;
         ifc::Enumerator const* enumerator_;

--- a/lib/reflifc/include/reflifc/decl/Field.h
+++ b/lib/reflifc/include/reflifc/decl/Field.h
@@ -28,6 +28,8 @@ namespace reflifc
         bool has_initializer() const;
         Expression initializer() const;
 
+        ifc::File const* containing_file() const { return ifc_; }
+
     private:
         ifc::File const* ifc_;
         ifc::FieldDeclaration const* field_;

--- a/lib/reflifc/include/reflifc/decl/Function.h
+++ b/lib/reflifc/include/reflifc/decl/Function.h
@@ -30,6 +30,8 @@ namespace reflifc
 
         ifc::Access access() const;
 
+        ifc::File const* containing_file() const { return ifc_; }
+
     private:
         ifc::File const* ifc_;
         ifc::FunctionDeclaration const* func_;
@@ -48,6 +50,8 @@ namespace reflifc
         Declaration home_scope() const;
 
         ifc::Access access() const;
+
+        ifc::File const* containing_file() const { return ifc_; }
 
     private:
         ifc::File const* ifc_;
@@ -71,6 +75,8 @@ namespace reflifc
         ifc::NoexceptSpecification  eh_spec()       const;
         ifc::CallingConvention      convention()    const;
 
+        ifc::File const* containing_file() const { return ifc_; }
+
     private:
         ifc::TorType const& tor_type() const;
 
@@ -89,6 +95,8 @@ namespace reflifc
 
         ifc::Access access() const;
         Declaration home_scope() const;
+
+        ifc::File const* containing_file() const { return ifc_; }
 
     private:
         ifc::File const* ifc_;

--- a/lib/reflifc/include/reflifc/decl/Intrinsic.h
+++ b/lib/reflifc/include/reflifc/decl/Intrinsic.h
@@ -20,6 +20,8 @@ namespace reflifc
         Type        type()          const { return { ifc_, intrinsic_->type }; }
         Declaration home_scope()    const { return { ifc_, intrinsic_->home_scope }; }
 
+        ifc::File const* containing_file() const { return ifc_; }
+
     private:
         ifc::File const* ifc_;
         ifc::IntrinsicDeclaration const* intrinsic_;

--- a/lib/reflifc/include/reflifc/decl/Namespace.h
+++ b/lib/reflifc/include/reflifc/decl/Namespace.h
@@ -22,6 +22,8 @@ namespace reflifc
 
         bool is_inline() const { return ifc::is_inline(scope_); }
 
+        ifc::File const* containing_file() const { return &ifc_; }
+
     private:
         ifc::File const* ifc_;
         ifc::ScopeDeclaration const& scope_;

--- a/lib/reflifc/include/reflifc/decl/Parameter.h
+++ b/lib/reflifc/include/reflifc/decl/Parameter.h
@@ -25,6 +25,8 @@ namespace reflifc
         ifc::ParameterPosition position() const { return param_->position; }
         ifc::ParameterLevel level() const { return param_->level; }
 
+        ifc::File const* containing_file() const { return ifc_; }
+
     private:
         ifc::File const* ifc_;
         ifc::ParameterDeclaration const* param_;

--- a/lib/reflifc/include/reflifc/decl/Scope.h
+++ b/lib/reflifc/include/reflifc/decl/Scope.h
@@ -23,6 +23,8 @@ namespace reflifc
                 | std::views::transform([ifc = ifc_] (ifc::Declaration decl) { return Declaration(ifc, decl.index); });
         }
 
+        ifc::File const* containing_file() const { return ifc_; }
+
     private:
         ifc::File const* ifc_;
         ifc::ScopeIndex scope_;

--- a/lib/reflifc/include/reflifc/decl/ScopeDeclaration.h
+++ b/lib/reflifc/include/reflifc/decl/ScopeDeclaration.h
@@ -31,6 +31,8 @@ namespace reflifc
         ifc::BasicSpecifiers specifiers() const;
         ifc::TypeBasis kind() const;
 
+        ifc::File const* containing_file() const { return ifc_; }
+
     private:
         ifc::File const* ifc_;
         ifc::ScopeDeclaration const* scope_;

--- a/lib/reflifc/include/reflifc/decl/Specialization.h
+++ b/lib/reflifc/include/reflifc/decl/Specialization.h
@@ -20,6 +20,8 @@ namespace reflifc
         Declaration primary_template()  const;
         TupleExpressionView arguments() const;
 
+        ifc::File const* containing_file() const { return ifc_; }
+
     private:
         ifc::File const* ifc_;
         ifc::SpecializationForm const* form_;
@@ -41,6 +43,8 @@ namespace reflifc
         ifc::Access access() const;
         ifc::BasicSpecifiers specifiers() const;
 
+        ifc::File const* containing_file() const { return ifc_; }
+
     private:
         ifc::File const* ifc_;
         ifc::PartialSpecialization const* spec_;
@@ -57,6 +61,8 @@ namespace reflifc
         Declaration entity() const;
         ifc::SpecializationSort sort() const;
         SpecializationForm form() const;
+
+        ifc::File const* containing_file() const { return ifc_; }
 
     private:
         ifc::File const* ifc_;

--- a/lib/reflifc/include/reflifc/decl/TemplateDeclaration.h
+++ b/lib/reflifc/include/reflifc/decl/TemplateDeclaration.h
@@ -25,6 +25,8 @@ namespace reflifc
         ifc::Access access() const;
         ifc::BasicSpecifiers specifiers() const;
 
+        ifc::File const* containing_file() const { return ifc_; }
+
     private:
         ifc::File const* ifc_;
         ifc::TemplateDeclaration const* template_;

--- a/lib/reflifc/include/reflifc/decl/UsingDeclaration.h
+++ b/lib/reflifc/include/reflifc/decl/UsingDeclaration.h
@@ -18,6 +18,8 @@ namespace reflifc
         Declaration resolution() const;
         Declaration home_scope() const;
 
+        ifc::File const* containing_file() const { return ifc_; }
+
     private:
         ifc::File const* ifc_;
         ifc::UsingDeclaration const* using_decl_;

--- a/lib/reflifc/include/reflifc/decl/Variable.h
+++ b/lib/reflifc/include/reflifc/decl/Variable.h
@@ -29,6 +29,8 @@ namespace reflifc
         bool has_initializer() const;
         Expression initializer() const;
 
+        ifc::File const* containing_file() const { return ifc_; }
+
     private:
         ifc::File const* ifc_;
         ifc::VariableDeclaration const* var_;


### PR DESCRIPTION
Added `containing_file()` to all declarations returning their `ifc::File`.

This change is branched from #29 . Feel free to pull that one first, I will fix any merge conflicts that arise.
The work for this PR is done in b4d1b69d6bf623f8e3f1006d23ea6172982aff3d