### PR TITLE
Finalised Name.h implementation

### DIFF
--- a/lib/core/include/ifc/Expression.h
+++ b/lib/core/include/ifc/Expression.h
@@ -4,10 +4,11 @@
 #include "DeclarationFwd.h"
 #include "NameFwd.h"
 #include "TypeFwd.h"
+#include "SyntaxTreeFwd.h"
 
 #include "Literal.h"
 #include "SourceLocation.h"
-#include "SyntaxTreeFwd.h"
+#include "Operator.h"
 
 #include "common_types.h"
 
@@ -181,71 +182,6 @@ namespace ifc
         PARTITION_SORT(ExprSort::PackedTemplateArguments);
     };
 
-    enum class MonadicOperator
-    {
-        Unknown         = 0x00,
-
-        Plus            = 0x01,
-        Negate          = 0x02,
-        Deref           = 0x03,
-        Address         = 0x04,
-        Complement      = 0x05,
-        Not             = 0x06,
-        PreIncrement    = 0x07,
-        PreDecrement    = 0x08,
-        PostIncrement   = 0x09,
-        PostDecrement   = 0x0A,
-        Truncate        = 0x0B,
-        Ceil            = 0x0C,
-        Floor           = 0x0D,
-        Paren           = 0x0E,
-        Brace           = 0x0F,
-        // TODO
-
-        MsvcIsNothrowDestructible = 0x41B,
-        // TODO
-    };
-
-    inline const char * to_string(MonadicOperator op)
-    {
-        switch (op)
-        {
-        case MonadicOperator::Unknown:
-            return "Unknown";
-        case MonadicOperator::Plus:
-            return "+";
-        case MonadicOperator::Negate:
-            return "-";
-        case MonadicOperator::Deref:
-            return "*";
-        case MonadicOperator::Address:
-            return "&";
-        case MonadicOperator::Complement:
-            return "~";
-        case MonadicOperator::Not:
-            return "!";
-        case MonadicOperator::PreIncrement:
-            return "(pre)++";
-        case MonadicOperator::PreDecrement:
-            return "(pre)--";
-        case MonadicOperator::PostIncrement:
-            return "(post)++";
-        case MonadicOperator::PostDecrement:
-            return "(post)--";
-        case MonadicOperator::Truncate:
-            return "(truncate)";
-        case MonadicOperator::Ceil:
-            return "(ceil)";
-        case MonadicOperator::Floor:
-            return "(floor)";
-        case MonadicOperator::Paren:
-            return "(paren)";
-        case MonadicOperator::Brace:
-            return "{brace}";
-        }
-        return "Unknown";
-    }
-
     struct MonadExpression : ExpressionBase
     {
         DeclIndex impl;
@@ -255,127 +191,6 @@ namespace ifc
         PARTITION_NAME("expr.monad");
         PARTITION_SORT(ExprSort::Monad);
     };
-
-    enum class DyadicOperator
-    {
-        Unknown     = 0x00,
-        // Arithmetic
-        Plus            = 0x01,
-        Minus           = 0x02,
-        Mult            = 0x03,
-        Slash           = 0x04,
-        Modulo          = 0x05,
-        Remaniner       = 0x06,
-        // Bitwise
-        Bitand          = 0x07,
-        Bitor           = 0x08,
-        Bitxor          = 0x09,
-        Lshift          = 0x0A,
-        Rshift          = 0x0B,
-        // Comparison
-        Equal           = 0x0C,
-        NotEqual        = 0x0D,
-        Less            = 0x0E,
-        LessEqual       = 0x0F,
-        Greater         = 0x10,
-        GreaterEqual    = 0x11,
-        Compare         = 0x12,
-        // Logical
-        LogicAnd        = 0x13,
-        LogicOr         = 0x14,
-        // Assign
-        Assign          = 0x15,
-        PlusAssign      = 0x16,
-        MinusAssign     = 0x17,
-        MultAssign      = 0x18,
-        SlashAssign     = 0x19,
-        ModuloAssign    = 0x1A,
-        BitandAssign    = 0x1B,
-        BitorAssign     = 0x1C,
-        BitxorAssign    = 0x1D,
-        LshiftAssign    = 0x1E,
-        RshiftAssign    = 0x1F,
-
-        Dot             = 0x21,
-        Arrow           = 0x22,
-        Apply           = 0x26,
-        Index           = 0x27,
-        // TODO
-
-        MsvcIsBaseOf        = 0x40A,
-        MsvcIsConvertibleTo = 0x40B,
-        // TODO
-    };
-
-    inline const char * to_string(DyadicOperator op)
-    {
-        switch (op)
-        {
-        case DyadicOperator::Unknown:
-            return "Unknown";
-        case DyadicOperator::Plus:
-            return "+";
-        case DyadicOperator::Minus:
-            return "-";
-        case DyadicOperator::Mult:
-            return "*";
-        case DyadicOperator::Slash:
-            return "/";
-        case DyadicOperator::Modulo:
-            return "%";
-        case DyadicOperator::Bitand:
-            return "&";
-        case DyadicOperator::Bitor:
-            return "|";
-        case DyadicOperator::Bitxor:
-            return "^";
-        case DyadicOperator::Lshift:
-            return "<<";
-        case DyadicOperator::Rshift:
-            return ">>";
-        case DyadicOperator::Equal:
-            return "==";
-        case DyadicOperator::NotEqual:
-            return "!=";
-        case DyadicOperator::Less:
-            return "<";
-        case DyadicOperator::LessEqual:
-            return "<=";
-        case DyadicOperator::Greater:
-            return ">";
-        case DyadicOperator::GreaterEqual:
-            return ">=";
-        case DyadicOperator::Compare:
-            return "<=>";
-        case DyadicOperator::LogicAnd:
-            return "&&";
-        case DyadicOperator::LogicOr:
-            return "||";
-        case DyadicOperator::Assign:
-            return "=";
-        case DyadicOperator::PlusAssign:
-            return "+=";
-        case DyadicOperator::MinusAssign:
-            return "-=";
-        case DyadicOperator::MultAssign:
-            return "*=";
-        case DyadicOperator::SlashAssign:
-            return "/=";
-        case DyadicOperator::ModuloAssign:
-            return "%=";
-        case DyadicOperator::BitandAssign:
-            return "&=";
-        case DyadicOperator::BitorAssign:
-            return "|=";
-        case DyadicOperator::BitxorAssign:
-            return "^=";
-        case DyadicOperator::LshiftAssign:
-            return "<<=";
-        case DyadicOperator::RshiftAssign:
-            return ">>=";
-        }
-        return "Unknown";
-    }
 
     struct DyadExpression : ExpressionBase
     {
@@ -393,16 +208,6 @@ namespace ifc
 
         PARTITION_NAME("expr.strings");
         PARTITION_SORT(ExprSort::String);
-    };
-
-    enum class StorageOperator
-    {
-        Unknown,
-        AllocateSingle,
-        AllocateArray,
-        DeallocateSingle,
-        DeallocateArray,
-        MSVC = 0x7DE,
     };
 
     struct CallExpression : ExpressionBase

--- a/lib/core/include/ifc/File.h
+++ b/lib/core/include/ifc/File.h
@@ -124,9 +124,13 @@ namespace ifc
         Partition<SyntaxIndex, Index>   syntax_heap() const;
 
         // Names
-        Partition<OperatorFunctionName, NameIndex>  operator_names() const;
-        Partition<SpecializationName, NameIndex>    specialization_names() const;
-        Partition<LiteralName, NameIndex>           literal_names() const;
+        Partition<OperatorFunctionName, NameIndex>      operator_names() const;
+        Partition<ConversionFunctionName, NameIndex>    conversion_function_names() const;
+        Partition<LiteralName, NameIndex>               literal_names() const;
+        Partition<TemplateName, NameIndex>              template_names() const;
+        Partition<SpecializationName, NameIndex>        specialization_names() const;
+        Partition<SourceFileName, NameIndex>            source_file_names() const;
+        Partition<DeductionGuideName, NameIndex>        deduction_guide_names() const;
 
         // Charts
         Partition<ChartUnilevel, ChartIndex>    unilevel_charts() const;

--- a/lib/core/include/ifc/Name.h
+++ b/lib/core/include/ifc/Name.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "NameFwd.h"
+#include "TypeFwd.h"
+#include "DeclarationFwd.h"
 #include "ExpressionFwd.h"
 
 #include "common_types.h"
@@ -65,6 +67,31 @@ namespace ifc
         PARTITION_SORT(NameSort::Operator);
     };
 
+    struct ConversionFunctionName
+	{
+		TypeIndex target;
+        TextOffset encoded;
+
+		PARTITION_NAME("name.conversion");
+		PARTITION_SORT(NameSort::Conversion);
+	};
+
+    struct LiteralName
+    {
+        TextOffset encoded;
+
+        PARTITION_NAME("name.literal");
+        PARTITION_SORT(NameSort::Literal);
+    };
+
+    struct TemplateName
+    {
+        NameIndex name;
+
+        PARTITION_NAME("name.template");
+        PARTITION_SORT(NameSort::Template);
+    };
+
     struct SpecializationName
     {
         NameIndex primary;
@@ -74,11 +101,20 @@ namespace ifc
         PARTITION_SORT(NameSort::Specialization);
     };
 
-    struct LiteralName
-    {
-        TextOffset encoded;
+    struct SourceFileName
+	{
+		TextOffset path;
+        TextOffset guard;
 
-        PARTITION_NAME("name.literal");
-        PARTITION_SORT(NameSort::Literal);
-    };
+		PARTITION_NAME("name.source-file");
+		PARTITION_SORT(NameSort::SourceFile);
+	};
+
+	struct DeductionGuideName
+	{
+		DeclIndex primary_template;
+
+		PARTITION_NAME("name.guide");
+		PARTITION_SORT(NameSort::Guide);
+	};
 }

--- a/lib/core/include/ifc/Name.h
+++ b/lib/core/include/ifc/Name.h
@@ -5,6 +5,8 @@
 #include "DeclarationFwd.h"
 #include "ExpressionFwd.h"
 
+#include "Operator.h"
+
 #include "common_types.h"
 
 namespace ifc
@@ -19,43 +21,6 @@ namespace ifc
         Specialization  = 0x05,
         SourceFile      = 0x06,
         Guide           = 0x07,
-    };
-
-    struct Operator
-    {
-    private:
-        uint16_t tag    : 4;
-        uint16_t index  : 12;
-
-    public:
-        enum class Sort
-        {
-            Niladic = 0x00,
-            Monadic = 0x01,
-            Dyadic  = 0x02,
-            Triadic = 0x03,
-            Storage = 0x0E,
-            Variadic= 0x0F,
-        };
-
-        Sort sort() const
-        {
-            return static_cast<Sort>(tag);
-        }
-
-        template<typename E>
-        E value() const
-        {
-            return static_cast<E>(index);
-        }
-    };
-
-    static_assert(sizeof(Operator) == sizeof(uint16_t));
-
-    enum class VariadicOperatorSort
-    {
-        MsvcIsConstructible = 0x402,
-        // TODO
     };
 
     struct OperatorFunctionName

--- a/lib/core/include/ifc/NameFwd.h
+++ b/lib/core/include/ifc/NameFwd.h
@@ -8,6 +8,10 @@ namespace ifc
     using NameIndex = AbstractReference<3, NameSort>;
 
     struct OperatorFunctionName;
-    struct SpecializationName;
+    struct ConversionFunctionName;
     struct LiteralName;
+    struct TemplateName;
+    struct SpecializationName;
+    struct SourceFileName;
+    struct DeductionGuideName;
 }

--- a/lib/core/include/ifc/Operator.h
+++ b/lib/core/include/ifc/Operator.h
@@ -1,0 +1,383 @@
+#pragma once
+
+#include <cstdint>
+
+
+namespace ifc
+{
+    // The kind of an operator.
+    enum class OperatorSort : uint16_t
+    {
+        Niladic = 0x00,
+        Monadic = 0x01,
+        Dyadic = 0x02,
+        Triadic = 0x03,
+        Storage = 0x0E,
+        Variadic = 0x0F,
+    };
+
+    // Like an AbstractReference, but for operators types.
+    struct Operator
+    {
+    private:
+        uint16_t tag : 4;
+        uint16_t index : 12;
+
+    public:
+        OperatorSort sort() const
+        {
+            return static_cast<OperatorSort>(tag);
+        }
+
+        template<typename E>
+        E value() const
+        {
+            return static_cast<E>(index);
+        }
+    };
+
+    static_assert(sizeof(Operator) == sizeof(uint16_t));
+
+    // An operator accepting no arguments.
+    enum class NiladicOperator : uint16_t
+    {
+        Unknown             = 0x00,
+        Phantom             = 0x01,
+        Constant            = 0x02,
+        Nil                 = 0x03,
+        Msvc                = 0x400,
+        MsvcConstantObject  = 0x401,
+        MsvcLambda          = 0x402
+    };
+
+    // An operator accepting one argument.
+    enum class MonadicOperator : uint16_t
+    {
+        Unknown                             = 0x00,
+        Plus                                = 0x01,
+        Negate                              = 0x02,
+        Deref                               = 0x03,
+        Address                             = 0x04,
+        Complement                          = 0x05,
+        Not                                 = 0x06,
+        PreIncrement                        = 0x07,
+        PreDecrement                        = 0x08,
+        PostIncrement                       = 0x09,
+        PostDecrement                       = 0x0A,
+        Truncate                            = 0x0B,
+        Ceil                                = 0x0C,
+        Floor                               = 0x0D,
+        Paren                               = 0x0E,
+        Brace                               = 0x0F,
+        Alignas                             = 0x10,
+        Alignof                             = 0x11,
+        Sizeof                              = 0x12,
+        Cardinality                         = 0x13,
+        Typeid                              = 0x14,
+        Noexcept                            = 0x15,
+        Requires                            = 0x16,
+        CoReturn                            = 0x17,
+        Await                               = 0x18,
+        Yield                               = 0x19,
+        Throw                               = 0x1A,
+        New                                 = 0x1B,
+        Delete                              = 0x1C,
+        DeleteArray                         = 0x1D,
+        Expand                              = 0x1E,
+        Read                                = 0x1F,
+        Materialize                         = 0x20,
+        PseudoDtorCall                      = 0x21,
+        LookupGlobally                      = 0x22,
+        Msvc                                = 0x400,
+        MsvcAssume                          = 0x401,
+        MsvcAlignof                         = 0x402,
+        MsvcUuidof                          = 0x403,
+        MsvcIsClass                         = 0x404,
+        MsvcIsUnion                         = 0x405,
+        MsvcIsEnum                          = 0x406,
+        MsvcIsPolymorphic                   = 0x407,
+        MsvcIsEmpty                         = 0x408,
+        MsvcIsTriviallyCopyConstructible    = 0x409,
+        MsvcIsTriviallyCopyAssignable       = 0x40A,
+        MsvcIsTriviallyDestructible         = 0x40B,
+        MsvcHasVirtualDestructor            = 0x40C,
+        MsvcIsNothrowCopyConstructible      = 0x40D,
+        MsvcIsNothrowCopyAssignable         = 0x40E,
+        MsvcIsPod                           = 0x40F,
+        MsvcIsAbstract                      = 0x410,
+        MsvcIsTrivial                       = 0x411,
+        MsvcIsTriviallyCopyable             = 0x412,
+        MsvcIsStandardLayout                = 0x413,
+        MsvcIsLiteralType                   = 0x414,
+        MsvcIsTriviallyMoveConstructible    = 0x415,
+        MsvcHasTrivialMoveAssign            = 0x416,
+        MsvcIsTriviallyMoveAssignable       = 0x417,
+        MsvcIsNothrowMoveAssignable         = 0x418,
+        MsvcUnderlyingType                  = 0x419,
+        MsvcIsDestructible                  = 0x41A,
+        MsvcIsNothrowDestructible           = 0x41B,
+        MsvcHasUniqueObjectRepresentations  = 0x41C,
+        MsvcIsAggregate                     = 0x41D,
+        MsvcBuiltinAddressOf                = 0x41E,
+        MsvcIsRefClass                      = 0x41F,
+        MsvcIsValueClass                    = 0x420,
+        MsvcIsSimpleValueClass              = 0x421,
+        MsvcIsInterfaceClass                = 0x422,
+        MsvcIsDelegate                      = 0x423,
+        MsvcIsFinal                         = 0x424,
+        MsvcIsSealed                        = 0x425,
+        MsvcHasFinalizer                    = 0x426,
+        MsvcHasCopy                         = 0x427,
+        MsvcHasAssign                       = 0x428,
+        MsvcHasUserDestructor               = 0x429,
+        MsvcConfusion                       = 0xFE0,
+        MsvcConfusedExpand                  = 0xFE1,
+        MsvcConfusedDependentSizeof         = 0xFE2,
+        MsvcConfusedPopState                = 0xFE3,
+        MsvcConfusedDtorAction              = 0xFE4,
+        MsvcConfusedVtorDisplacement        = 0xFE5,
+        MsvcConfusedDependentExpression     = 0xFE6,
+        MsvcConfusedSubstitution            = 0xFE7,
+        MsvcConfusedAggregateReturn         = 0xFE8
+    };
+
+    // An operator accepting two arguments.
+    enum class DyadicOperator : uint16_t
+    {
+        Unknown                                         = 0x00,
+        Plus                                            = 0x01,
+        Minus                                           = 0x02,
+        Mult                                            = 0x03,
+        Slash                                           = 0x04,
+        Modulo                                          = 0x05,
+        Remainder                                       = 0x06,
+        Bitand                                          = 0x07,
+        Bitor                                           = 0x08,
+        Bitxor                                          = 0x09,
+        Lshift                                          = 0x0A,
+        Rshift                                          = 0x0B,
+        Equal                                           = 0x0C,
+        NotEqual                                        = 0x0D,
+        Less                                            = 0x0E,
+        LessEqual                                       = 0x0F,
+        Greater                                         = 0x10,
+        GreaterEqual                                    = 0x11,
+        Compare                                         = 0x12,
+        LogicAnd                                        = 0x13,
+        LogicOr                                         = 0x14,
+        Assign                                          = 0x15,
+        PlusAssign                                      = 0x16,
+        MinusAssign                                     = 0x17,
+        MultAssign                                      = 0x18,
+        SlashAssign                                     = 0x19,
+        ModuloAssign                                    = 0x1A,
+        BitandAssign                                    = 0x1B,
+        BitorAssign                                     = 0x1C,
+        BitxorAssign                                    = 0x1D,
+        LshiftAssign                                    = 0x1E,
+        RshiftAssign                                    = 0x1F,
+        Comma                                           = 0x20,
+        Dot                                             = 0x21,
+        Arrow                                           = 0x22,
+        DotStar                                         = 0x23,
+        ArrowStar                                       = 0x24,
+        Curry                                           = 0x25,
+        Apply                                           = 0x26,
+        Index                                           = 0x27,
+        DefaultAt                                       = 0x28,
+        New                                             = 0x29,
+        NewArray                                        = 0x2A,
+        Destruct                                        = 0x2B,
+        DestructAt                                      = 0x2C,
+        Cleanup                                         = 0x2D,
+        Qualification                                   = 0x2E,
+        Promote                                         = 0x2F,
+        Demote                                          = 0x30,
+        Coerce                                          = 0x31,
+        Rewrite                                         = 0x32,
+        Bless                                           = 0x33,
+        Cast                                            = 0x34,
+        ExplicitConversion                              = 0x35,
+        ReinterpretCast                                 = 0x36,
+        StaticCast                                      = 0x37,
+        ConstCast                                       = 0x38,
+        DynamicCast                                     = 0x39,
+        Narrow                                          = 0x3A,
+        Widen                                           = 0x3B,
+        Pretend                                         = 0x3C,
+        Closure                                         = 0x3D,
+        ZeroInitialize                                  = 0x3E,
+        ClearStorage                                    = 0x3F,
+        Select                                          = 0x40,
+        Msvc                                            = 0x400,
+        MsvcTryCast                                     = 0x401,
+        MsvcCurry                                       = 0x402,
+        MsvcVirtualCurry                                = 0x403,
+        MsvcAlign                                       = 0x404,
+        MsvcBitSpan                                     = 0x405,
+        MsvcBitfieldAccess                              = 0x406,
+        MsvcObscureBitfieldAccess                       = 0x407,
+        MsvcInitialize                                  = 0x408,
+        MsvcBuiltinOffsetOf                             = 0x409,
+        MsvcIsBaseOf                                    = 0x40A,
+        MsvcIsConvertibleTo                             = 0x40B,
+        MsvcIsTriviallyAssignable                       = 0x40C,
+        MsvcIsNothrowAssignable                         = 0x40D,
+        MsvcIsAssignable                                = 0x40E,
+        MsvcIsAssignableNocheck                         = 0x40F,
+        MsvcBuiltinBitCast                              = 0x410,
+        MsvcBuiltinIsLayoutCompatible                   = 0x411,
+        MsvcBuiltinIsPointerInterconvertibleBaseOf      = 0x412,
+        MsvcBuiltinIsPointerInterconvertibleWithClass   = 0x413,
+        MsvcBuiltinIsCorrespondingMember                = 0x414,
+        MsvcIntrinsic                                   = 0x415,
+        MsvcSaturatedArithmetic                         = 0x416,
+        MsvcBuiltinAllocationAnnotation                 = 0x417
+    };
+
+    // An operator accepting three arguments.
+    enum class TriadicOperator : uint16_t
+    {
+        Unknown                 = 0x00,
+        Choice                  = 0x01,
+        ConstructAt             = 0x02,
+        Initialize              = 0x03,
+        Msvc                    = 0x400,
+        MsvcConfusion           = 0xFE0,
+        MsvcConfusedPushState   = 0xFE1,
+        MsvcConfusedChoice      = 0xFE2
+    };
+
+    // A storage allocation or deallocation operator.
+    enum class StorageOperator : uint16_t
+    {
+        Unknown             = 0x00,
+        AllocateSingle      = 0x01,
+        AllocateArray       = 0x02,
+        DeallocateSingle    = 0x03,
+        DeallocateArray     = 0x04,
+        MSVC                = 0x7DE
+    };
+
+    // An operator accepting any number of arguments.
+    enum class VariadicOperator : uint16_t
+    {
+        Unknown                         = 0x00,
+        Collection                      = 0x01,
+        Sequence                        = 0x02,
+        Msvc                            = 0x400,
+        MsvcHasTrivialConstructor       = 0x401,
+        MsvcIsConstructible             = 0x402,
+        MsvcIsNothrowConstructible      = 0x403,
+        MsvcIsTriviallyConstructible    = 0x404
+    };
+
+
+    inline const char* to_string(MonadicOperator op)
+    {
+        switch (op) {
+        case MonadicOperator::Unknown:
+            return "Unknown";
+        case MonadicOperator::Plus:
+            return "+";
+        case MonadicOperator::Negate:
+            return "-";
+        case MonadicOperator::Deref:
+            return "*";
+        case MonadicOperator::Address:
+            return "&";
+        case MonadicOperator::Complement:
+            return "~";
+        case MonadicOperator::Not:
+            return "!";
+        case MonadicOperator::PreIncrement:
+            return "(pre)++";
+        case MonadicOperator::PreDecrement:
+            return "(pre)--";
+        case MonadicOperator::PostIncrement:
+            return "(post)++";
+        case MonadicOperator::PostDecrement:
+            return "(post)--";
+        case MonadicOperator::Truncate:
+            return "(truncate)";
+        case MonadicOperator::Ceil:
+            return "(ceil)";
+        case MonadicOperator::Floor:
+            return "(floor)";
+        case MonadicOperator::Paren:
+            return "(paren)";
+        case MonadicOperator::Brace:
+            return "{brace}";
+        }
+        return "Unknown";
+    }
+
+    inline const char* to_string(DyadicOperator op)
+    {
+        switch (op) {
+        case DyadicOperator::Unknown:
+            return "Unknown";
+        case DyadicOperator::Plus:
+            return "+";
+        case DyadicOperator::Minus:
+            return "-";
+        case DyadicOperator::Mult:
+            return "*";
+        case DyadicOperator::Slash:
+            return "/";
+        case DyadicOperator::Modulo:
+            return "%";
+        case DyadicOperator::Bitand:
+            return "&";
+        case DyadicOperator::Bitor:
+            return "|";
+        case DyadicOperator::Bitxor:
+            return "^";
+        case DyadicOperator::Lshift:
+            return "<<";
+        case DyadicOperator::Rshift:
+            return ">>";
+        case DyadicOperator::Equal:
+            return "==";
+        case DyadicOperator::NotEqual:
+            return "!=";
+        case DyadicOperator::Less:
+            return "<";
+        case DyadicOperator::LessEqual:
+            return "<=";
+        case DyadicOperator::Greater:
+            return ">";
+        case DyadicOperator::GreaterEqual:
+            return ">=";
+        case DyadicOperator::Compare:
+            return "<=>";
+        case DyadicOperator::LogicAnd:
+            return "&&";
+        case DyadicOperator::LogicOr:
+            return "||";
+        case DyadicOperator::Assign:
+            return "=";
+        case DyadicOperator::PlusAssign:
+            return "+=";
+        case DyadicOperator::MinusAssign:
+            return "-=";
+        case DyadicOperator::MultAssign:
+            return "*=";
+        case DyadicOperator::SlashAssign:
+            return "/=";
+        case DyadicOperator::ModuloAssign:
+            return "%=";
+        case DyadicOperator::BitandAssign:
+            return "&=";
+        case DyadicOperator::BitorAssign:
+            return "|=";
+        case DyadicOperator::BitxorAssign:
+            return "^=";
+        case DyadicOperator::LshiftAssign:
+            return "<<=";
+        case DyadicOperator::RshiftAssign:
+            return ">>=";
+        }
+        return "Unknown";
+    }
+}

--- a/lib/core/src/File.cpp
+++ b/lib/core/src/File.cpp
@@ -105,8 +105,12 @@ namespace ifc
             AttrHeap,
             SyntaxHeap,
             OperatorNames,
-            SpecializationNames,
+            ConversionNames,
             LiteralNames,
+            TemplateNames,
+            SpecializationNames,
+            SourceFileNames,
+            DeductionGuideNames,
             UnilevelCharts,
             MultilevelCharts,
             IntegerLiterals,
@@ -868,14 +872,34 @@ namespace ifc
         return impl_->get_and_cache_partition<OperatorFunctionName, NameIndex>(FilePartitionCache::OperatorNames);
     }
 
+    Partition<ConversionFunctionName, NameIndex> File::conversion_function_names() const
+	{
+		return impl_->get_and_cache_partition<ConversionFunctionName, NameIndex>(FilePartitionCache::ConversionNames);
+	}
+
+    Partition<LiteralName, NameIndex> File::literal_names() const
+    {
+        return impl_->get_and_cache_partition<LiteralName, NameIndex>(FilePartitionCache::LiteralNames);
+    }
+
+    Partition<TemplateName, NameIndex> File::template_names() const
+	{
+		return impl_->get_and_cache_partition<TemplateName, NameIndex>(FilePartitionCache::TemplateNames);
+	}
+
     Partition<SpecializationName, NameIndex> File::specialization_names() const
     {
         return impl_->get_and_cache_partition<SpecializationName, NameIndex>(FilePartitionCache::SpecializationNames);
     }
 
-    Partition<LiteralName, NameIndex> File::literal_names() const
+    Partition<SourceFileName, NameIndex> File::source_file_names() const
+	{
+		return impl_->get_and_cache_partition<SourceFileName, NameIndex>(FilePartitionCache::SourceFileNames);
+	}
+
+    Partition<DeductionGuideName, NameIndex> File::deduction_guide_names() const
     {
-        return impl_->get_and_cache_partition<LiteralName, NameIndex>(FilePartitionCache::LiteralNames);
+		return impl_->get_and_cache_partition<DeductionGuideName, NameIndex>(FilePartitionCache::DeductionGuideNames);
     }
 
     // ------------------------------------------------------------------------

--- a/lib/reflifc/include/reflifc/Name.h
+++ b/lib/reflifc/include/reflifc/Name.h
@@ -11,6 +11,8 @@ namespace reflifc
 {
     struct SpecializationName;
     struct TupleExpressionView;
+    struct Declaration;
+    struct Type;
 
     struct Name
     {
@@ -25,19 +27,32 @@ namespace reflifc
             return !index_.is_null();
         }
 
-        bool        is_identifier() const;
-        char const* as_identifier() const;
+        bool                is_identifier() const;
+        char const*         as_identifier() const;
 
-        bool        is_operator() const;
-        char const* operator_name() const;
+        bool                is_operator() const;
+        char const*         operator_name() const;
+        ifc::Operator       get_operator() const;
 
-        ifc::Operator get_operator() const;
+        bool                is_literal() const;
+        char const*         as_literal() const;
 
-        bool        is_literal() const;
-        char const* as_literal() const;
+        bool                is_conversion() const;
+        char const*         as_conversion_name() const;
+        Type			    get_conversion_target_type() const;
+
+        bool                is_template() const;
+        Name				as_template() const;
 
         bool                is_specialization() const;
         SpecializationName  as_specialization() const;
+
+        bool                is_soure_file() const;
+        char const*         as_source_file() const;
+        char const*         get_source_file_header_guard() const;
+
+        bool                is_deduction_guide() const;
+        Declaration			as_deduction_guide() const;
 
         ifc::NameSort sort() const { return index_.sort(); }
 

--- a/lib/reflifc/src/Name.cpp
+++ b/lib/reflifc/src/Name.cpp
@@ -1,5 +1,8 @@
 ﻿#include "reflifc/Name.h"
+
 #include "reflifc/TupleView.h"
+#include "reflifc/Declaration.h"
+#include "reflifc/Type.h"
 
 #include <ifc/File.h>
 
@@ -22,8 +25,8 @@ namespace reflifc
 
     char const* Name::operator_name() const
     {
-        const auto operator_function_name = ifc_->operator_names()[index_];
-        return ifc_->get_string(operator_function_name.encoded);
+        const auto operator_function_text = ifc_->operator_names()[index_].encoded;
+        return ifc_->get_string(operator_function_text);
     }
 
     ifc::Operator Name::get_operator() const
@@ -38,7 +41,34 @@ namespace reflifc
 
     char const* Name::as_literal() const
     {
-        return ifc_->get_string(ifc_->literal_names()[index_].encoded);
+        const auto literal_text = ifc_->literal_names()[index_].encoded;
+        return ifc_->get_string(literal_text);
+    }
+
+    bool Name::is_conversion() const
+    {
+        return sort() == ifc::NameSort::Conversion;
+    }
+
+    char const* Name::as_conversion_name() const
+    {
+        const auto conversion_function_text = ifc_->conversion_function_names()[index_].encoded;
+        return ifc_->get_string(conversion_function_text);
+    }
+
+    Type Name::get_conversion_target_type() const
+    {
+        return Type{ ifc_, ifc_->conversion_function_names()[index_].target };
+    }
+
+    bool Name::is_template() const
+    {
+        return sort() == ifc::NameSort::Template;
+    }
+
+    Name Name::as_template() const
+    {
+        return Name{ ifc_, ifc_->template_names()[index_].name };
     }
 
     bool Name::is_specialization() const
@@ -49,6 +79,33 @@ namespace reflifc
     SpecializationName Name::as_specialization() const
     {
         return { ifc_, ifc_->specialization_names()[index_] };
+    }
+
+    bool Name::is_soure_file() const
+    {
+        return sort() == ifc::NameSort::SourceFile;
+    }
+
+    char const* Name::as_source_file() const
+    {
+        const auto source_filename_text = ifc_->source_file_names()[index_].path;
+        return ifc_->get_string(source_filename_text);
+    }
+
+    char const* Name::get_source_file_header_guard() const
+    {
+        const auto guard_text = ifc_->source_file_names()[index_].guard;
+        return ifc_->get_string(guard_text);
+    }
+
+    bool Name::is_deduction_guide() const
+    {
+        return sort() == ifc::NameSort::Guide;
+    }
+
+    Declaration Name::as_deduction_guide() const
+    {
+        return Declaration{ ifc_, ifc_->deduction_guide_names()[index_].primary_template };
     }
 
     Name SpecializationName::primary() const


### PR DESCRIPTION
I fully added everything added by the ifc spec to `Name.h` for _ifc-core_ and _reflifc_.

I also cleaned up the `Operator` definition from there and from `Expression.h` into it's own dedicated header.